### PR TITLE
Update to latest version of pantheon-systems/wordpress-bedrock-integrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "roots/wp-config": "1.0.0",
     "roots/wp-password-bcrypt": "1.1.0",
     "wpackagist-theme/twentytwentytwo": "^1.2",
-    "pantheon-systems/wordpress-bedrock-integrations": "^2.0",
+    "pantheon-systems/wordpress-bedrock-integrations": "^2.1",
     "pantheon-systems/pantheon-mu-plugin": "^1.0",
     "pantheon-systems/composer-scaffold": "^1.0"
   },


### PR DESCRIPTION
Resolves notice: `The allowed package pantheon-systems/wordpress-bedrock-integrations does not provide a file mapping for Composer Scaffold.`

Files from wordpress-bedrock-integrations are currently not being placed in the upstream as there was no release since the [key was changed](https://github.com/pantheon-systems/wordpress-composer-managed/commit/269f69959eeaa0d3c1ebedb6ea92395b308c10f2) from `drupal-scaffold` to `composer-scaffold`. See [2.0.0](https://github.com/pantheon-systems/wordpress-bedrock-integrations/blob/2.0.0/composer.json#L24) tag vs [2.1.0](https://github.com/pantheon-systems/wordpress-bedrock-integrations/blob/2.1.0/composer.json#L24).

Additionally, `pantheon.upstream.yml` now lives in this repo, so it has been removed from `pantheon-systems/wordpress-bedrock-integrations`.