### PR TITLE
[CMS-801] Adjust wp-config

### DIFF
--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -168,26 +168,3 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ):
 	endif;
 
 endif;
-
-/*
-* Define wp-content directory outside of WordPress core directory
-*/
-define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/app' );
-define( 'WP_CONTENT_URL', WP_HOME . '/app' );
-
-/**
- * WordPress Database Table prefix.
- *
- * You can have multiple installations in one database if you give each
- * a unique prefix. Only numbers, letters, and underscores please!
- */
-$table_prefix = getenv( 'DB_PREFIX' ) !== false ? getenv( 'DB_PREFIX' ) : 'wp_';
-
-/* That's all, stop editing! Happy blogging. */
-
-/** Absolute path to the WordPress directory. */
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', dirname(__FILE__) . 'wp-config.php/');
-}
-/** Sets up WordPress vars and included files. */
-require_once( ABSPATH . 'wp-settings.php' );

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -13,5 +13,28 @@ if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['P
 } else {
     require_once dirname(__DIR__) . '/vendor/autoload.php';
     require_once dirname(__DIR__) . '/config/application.php';
-    require_once ABSPATH . 'wp-settings.php';
 }
+
+/*
+* Define wp-content directory outside of WordPress core directory
+*/
+define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/app' );
+define( 'WP_CONTENT_URL', WP_HOME . '/app' );
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = getenv( 'DB_PREFIX' ) !== false ? getenv( 'DB_PREFIX' ) : 'wp_';
+
+/* That's all, stop editing! Happy Pressing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', dirname( __FILE__ ) . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once( ABSPATH . 'wp-settings.php' );


### PR DESCRIPTION
Fixes WP-CLI error `Fatal error: Cannot redeclare wp_get_server_protocol() (previously declared in /code/web/wp/wp-includes/load.php:16) in /code/web/wp/wp-includes/load.php on line 15`.

Terminus:

<img width="667" alt="Screen Shot 2022-07-15 at 2 25 02 PM" src="https://user-images.githubusercontent.com/17913282/179305502-49d5eb93-1746-48f0-a8cb-8a2971e1fa62.png">

btool shell:

<img width="588" alt="Screen Shot 2022-07-15 at 2 27 09 PM" src="https://user-images.githubusercontent.com/17913282/179305675-bc24f6c0-aac7-46b0-8776-1f89dcb05037.png">
