### PR TITLE
[CMS-812] updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,46 @@
-# Application
+# This file contains .gitignore rules that are often used with Composer-based
+# WordPress projects. Because .gitignore is specific to your site and its
+# deployment processes, you may need to uncomment, add, or remove rules.
+
+# The /web/app/ directory is used in favor of /wp-content in a traditional
+# WordPress project. This is where files are uploaded to, where plugins and
+# themes are installed and where other writeable directories are created.
+# Plugin, theme and mu-plugin paths are defined later and handled differently,
+# but in most cases, we don't want to version control anything in here.
+# It's unlikely that you would need to change any of these rules.
 web/app/upgrade
 web/app/uploads/*
 !web/app/uploads/.gitkeep
 web/app/cache/*
 
-# WordPress
+# WordPress is installed in web/wp so that it can be fully managed by Composer.
+# This ensures that the WordPress directory is clean and doesn't contain any
+# files other than those that come with the WordPress package.
 web/wp
 web/.htaccess
 
-# Logs
+# Logfiles should always be ignored.
 *.log
 
-# Dotenv
+# Environment (.env) files should be ignored as they are generally personal.
+# However, the .env.example and .env.pantheon files are left so that they can be
+# viewed and modified. You should not store any credentials in your
+# .env.pantheon file. Instead, those can go into environment-specific .env
+# files. Constants saved in .env files will override those constants that are
+# defined in wp-config-pantheon.php.
 .env
 .env.*
 !.env.example
 !.env.pantheon
 
-# Composer
+# Generally you should only ignore the root vendor directory. These files are
+# managed by Composer and should not be version controlled. It may be necessary
+# to explicitly allow /vendor directories within plugins or themes that are not
+# available through Wpackagist (which mirrors WordPress.org), like projects
+# that pull from Packagist or custom GitHub repositories.
 /vendor
 
-# WP-CLI
+# Any local WP-CLI rules should not be version controlled.
 wp-cli.local.yml
 
 # :::::::::::::::::::::: Pantheon Additions ::::::::::::::::::::::

--- a/.gitignore
+++ b/.gitignore
@@ -73,17 +73,17 @@ web/app/plugins/*
 web/app/themes/twenty*
 
 # Private files
+# We want to ignore files inside web/private/ by default, but we don't want to
+# ignore the entire directory. The web/private/config directory is excluded from
+# this rule because this may contain information that should be shared across
+# environments and is not considered sensitive data. However, that exclusion
+# should be removed if that is not the case.
+!web/private/
+web/private/*
+!web/private/config/
 
 # Autoloader
 
 # Ignore files copied by scripts.
 web/index.php
 web/wp-cli.yml
-
-# Ignore private stuff (but don't ignore the directory itself).
-!web/private/
-web/private/*
-!web/private/scripts/
-web/private/scripts/quicksilver
-!web/private/config/
-/autoload.php

--- a/.gitignore
+++ b/.gitignore
@@ -56,11 +56,18 @@ wp-cli.local.yml
 web/app/mu-plugins/*/
 web/app/mu-plugins/loader.php
 
+# Plugins
+# Ignore the plugins directory by default. WordPress plugins should be managed
+# by Composer, where we have more control over the version constraints of the
+# plugins. If you have custom plugins, you will need to explicitly exclude them
+# from this rule like this:
+# !web/app/plugins/my-plugin
+web/app/plugins/*
+!web/app/plugins/.gitkeep
+
 # Themes
 
-# Ignore plugins (but don't ignore the directory itself).
-!web/app/plugins/
-web/app/plugins/*
+# Private files
 
 # Ignore themes (but don't ignore the directory itself).
 !web/app/themes/

--- a/.gitignore
+++ b/.gitignore
@@ -66,12 +66,15 @@ web/app/plugins/*
 !web/app/plugins/.gitkeep
 
 # Themes
+# We don't ignore all themes by default as these are most commonly where a
+# bulk of a site's custom code may be. However, we do ignore all of the
+# twenty-* themes by default. Any other Composer-managed themes should be
+# added to this list.
+web/app/themes/twenty*
 
 # Private files
 
-# Ignore themes (but don't ignore the directory itself).
-!web/app/themes/
-web/app/themes/*
+# Autoloader
 
 # Ignore files copied by scripts.
 web/index.php

--- a/.gitignore
+++ b/.gitignore
@@ -46,10 +46,17 @@ wp-cli.local.yml
 # :::::::::::::::::::::: Pantheon Additions ::::::::::::::::::::::
 
 # Must-use plugins
+# Ignore packages uploaded to mu-plugins by default. These area typically
+# managed by composer as wordpress-muplugins. If you have custom mu-plugins,
+# you will need to explicitly exclude them from this rule like this:
+# !web/app/mu-plugins/my-muplugin/
+# By default, individual mu-plugin files are not ignored, so any bare file in
+# mu-plugins is version controlled. Exceptions to this rule are made to specific
+# files managed by Composer.
+web/app/mu-plugins/*/
+web/app/mu-plugins/loader.php
 
-# Ignore mu-plugins (but don't ignore the directory itself).
-!web/app/mu-plugins/
-web/app/mu-plugins/*
+# Themes
 
 # Ignore plugins (but don't ignore the directory itself).
 !web/app/plugins/

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,10 @@ web/private/*
 !web/private/config/
 
 # Autoloader
+# This file loads the Composer autoloader and is moved to the root directory by
+# pantheon-systems/composer-scaffold. This should not be moved or removed or it
+# could prevent the site from working correctly.
+/autoload.php
 
 # Ignore files copied by scripts.
 web/index.php

--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,7 @@ wp-cli.local.yml
 
 # :::::::::::::::::::::: Pantheon Additions ::::::::::::::::::::::
 
-# Ignore the app directory
-web/app/*
+# Must-use plugins
 
 # Ignore mu-plugins (but don't ignore the directory itself).
 !web/app/mu-plugins/


### PR DESCRIPTION
This updated gitignore file attempts to simplify and verbosely explain the choices made in our gitignore file similar to the gitignore in `drupal-composer-managed`.

Additionally, it removes some unnecessary duplication that was present in our gitignore and removes some of the confusing exclusions (ignore this, but not that) that weren't really doing the thing that we wanted.