### PR TITLE
[CMS-830] composer.json updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
   ],
   "support": {
     "issues": "https://github.com/pantheon-systems/wordpress-composer-managed/issues",
+    "docs": "https://pantheon.io/docs/guides/wordpress-composer",
     "forum": "https://discuss.pantheon.io"
   },
   "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,16 @@
   "homepage": "https://pantheon.io/docs/guides/wordpress-composer",
   "authors": [
     {
+      "name": "John Spellman",
+      "email": "john.spellman@pantheon.io",
+      "homepage": "https://github.com/jspellman814"
+    },
+    {
+      "name": "Chris Reynolds",
+      "email": "chris.reynolds@pantheon.io",
+      "homepage": "https://github.com/jazzsequence"
+    },
+    {
       "name": "Scott Walkinshaw",
       "email": "scott.walkinshaw@gmail.com",
       "homepage": "https://github.com/swalkinshaw"

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "bedrock", "composer", "roots", "wordpress", "wp", "wp-config", "pantheon"
   ],
   "support": {
-    "issues": "https://github.com/roots/bedrock/issues",
-    "forum": "https://discourse.roots.io/category/bedrock"
+    "issues": "https://github.com/pantheon-systems/wordpress-composer-managed/issues",
+    "forum": "https://discuss.pantheon.io"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
   "homepage": "https://pantheon.io/docs/guides/wordpress-composer",
   "authors": [
     {
+      "name": "Pantheon Systems",
+      "homepage": "https://pantheon.io"
+    },
+    {
       "name": "John Spellman",
       "email": "john.spellman@pantheon.io",
       "homepage": "https://github.com/jspellman814"

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-  "name": "roots/bedrock",
+  "name": "pantheon-systems/wordpress-composer-managed",
   "type": "project",
   "license": "MIT",
-  "description": "WordPress boilerplate with Composer, easier configuration, and an improved folder structure",
-  "homepage": "https://roots.io/bedrock/",
+  "description": "Pantheon's recommended starting point for WordPress upstreams using the platform's Integrated Composer build process.",
+  "homepage": "https://pantheon.io/docs/guides/wordpress-composer",
   "authors": [
     {
       "name": "Scott Walkinshaw",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     }
   ],
   "keywords": [
-    "bedrock", "composer", "roots", "wordpress", "wp", "wp-config"
+    "bedrock", "composer", "roots", "wordpress", "wp", "wp-config", "pantheon"
   ],
   "support": {
     "issues": "https://github.com/roots/bedrock/issues",


### PR DESCRIPTION
Takes and declares ownership of the `composer.json` file for WordPress Composer Managed.

* updates the project name from `roots/bedrock` to `pantheon-systems/wordpress-composer-managed`
* updates the package description
* updates the package homepage
* updates the authors array to include pantheon engineers
* adds `pantheon` to the list of keywords
* updates the issues and forum links in `support`
* adds a `docs` link in `support`