### PR TITLE
[CMS-873] Rename remote for decoupled push

### DIFF
--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -10,8 +10,8 @@ set -euo pipefail
 
 . devops/scripts/commit-type.sh
 
-git remote add public "$UPSTREAM_DECOUPLED_REPO_REMOTE_URL"
-git fetch public
+git remote add decoupled "$UPSTREAM_DECOUPLED_REPO_REMOTE_URL"
+git fetch decoupled
 git checkout "${CIRCLE_BRANCH}"
 
 echo
@@ -50,7 +50,7 @@ cp devops/scripts/decoupledpatch.sh /tmp/decoupledpatch.sh
 cp devops/files/decoupled-README.md /tmp/decoupled-README.md
 
 # Cherry-pick commits not modifying circle config onto the release branch
-git checkout -b public --track public/main
+git checkout -b decoupled --track decoupled/main
 git pull
 
 if [[ "$CIRCLECI" != "" ]]; then
@@ -86,7 +86,7 @@ echo
 echo "Releasing to upstream org"
 echo
 
-# Push to the public repository
-git push public public:main
+# Push to the decoupled repository
+git push decoupled decoupled:main
 
 git checkout $CIRCLE_BRANCH


### PR DESCRIPTION
Fix `remote public already exists` error in deploy-decoupled-upstream script: https://app.circleci.com/pipelines/github/pantheon-systems/wordpress-composer-managed/96/workflows/1e7651e3-4cb7-4dbc-982a-2131fb819aaf/jobs/116