### PR TITLE
[CMS-956] Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,24 @@ web/app/plugins/*
 # added to this list.
 web/app/themes/twenty*
 
+# Other WordPress files and directories
+# Any other files or directories that should not be version controlled go here.
+# A lot of stuff from the non-Composer-managed WordPress upstream is repeated
+# here.
+web/app/backups/
+web/app/backupwordpress-*/
+web/app/blogs.dir/
+web/app/backup-db/
+web/app/cache/
+web/app/managewp/backups/
+web/app/updraft/
+web/app/upgrade/
+web/app/advanced-cache.php
+web/app/wp-cache-config.php
+web/wp-config-local.php
+sitemap.xml
+sitemap.xml.gz
+
 # Private files
 # We want to ignore files inside web/private/ by default, but we don't want to
 # ignore the entire directory. The web/private/config directory is excluded from
@@ -86,3 +104,44 @@ web/private/*
 # pantheon-systems/composer-scaffold. This should not be moved or removed or it
 # could prevent the site from working correctly.
 /autoload.php
+
+# Pantheon.upstream.yml
+# Avoid accidental modification of pantheon.upstream.yml in sites
+# created from this upstream
+pantheon.upstream.yml
+
+# Files
+# Common files that should not be version controlled.
+# Packages #
+############
+*.7z
+*.dmg
+*.gz
+*.bz2
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+*.tgz
+!web/wp/wp-includes/**/*.gz
+
+# Logs and databases #
+######################
+*.log
+*.sql
+
+# OS generated files #
+######################
+.DS_Store*
+ehthumbs.db
+Thumbs.db
+._*
+
+# Vim generated files #
+######################
+*.un~
+
+# SASS #
+##########
+.sass-cache


### PR DESCRIPTION
Copies and updates missing pieces from the [default WordPress upstream gitignore](https://github.com/pantheon-systems/WordPress/blob/default/.gitignore) into Composer-managed gitignore.