### PR TITLE
Link to Pantheon Upstreams repo in forking heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ terminus site:create --org ORG --region REGION -- <site_name> <label> "WordPress
 1. In the Dev environment, click **Visit Development Site** and follow the prompts to complete the CMS installation.
 2. [Clone the site locally](https://pantheon.io/docs/local-development#get-the-code) and run `composer install`.
 
-### Fork this repository to create a custom upstream (advanced)
+### Fork [this repository](https://github.com/pantheon-upstreams/wordpress-composer-managed) to create a custom upstream (advanced)
 
 **Note:** It's highly recommended that you use the Pantheon-maintained upstream in favor of creating and managing a custom upstream so you can be sure to receive the latest updates. Managing your own custom upstream means that you assume ownership of the upstream and all changes made to it and assumes that you will manage all updates to the upstream.
 


### PR DESCRIPTION
We don't want people to fork from **this** repository, we want them to fork from `pantheon-upstreams`. This adds a link to that repository so they will (hopefully) go there to create the fork.