### PR TITLE
[BUGS-5326] Add decoupled-release-pointer tag

### DIFF
--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -20,8 +20,8 @@ echo "Preparing to release to upstream org"
 echo "-----------------------------------------------------------------------"
 echo
 
-# List commits between release-pointer and HEAD, in reverse
-newcommits=$(git log release-pointer..HEAD --reverse --pretty=format:"%h")
+# List commits between decoupled-release-pointer and HEAD, in reverse
+newcommits=$(git log decoupled-release-pointer..HEAD --reverse --pretty=format:"%h")
 commits=()
 
 # Identify commits that should be released
@@ -90,3 +90,9 @@ echo
 git push decoupled decoupled:main
 
 git checkout $CIRCLE_BRANCH
+
+# update the decoupled-release-pointer
+git tag -f -m 'Last commit set on upstream repo' decoupled-release-pointer HEAD
+
+# Push decoupled-release-pointer
+git push -f origin decoupled-release-pointer

--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -10,6 +10,11 @@ set -euo pipefail
 
 . devops/scripts/commit-type.sh
 
+# Copy patch and README file to tmp directory for use after checkout.
+echo "Copying decoupledpatch and decoupled-README to /tmp for use later."
+cp devops/scripts/decoupledpatch.sh /tmp/decoupledpatch.sh
+cp devops/files/decoupled-README.md /tmp/decoupled-README.md
+
 git remote add decoupled "$UPSTREAM_DECOUPLED_REPO_REMOTE_URL"
 git fetch decoupled
 git checkout "${CIRCLE_BRANCH}"
@@ -43,11 +48,6 @@ if [[ ${#commits[@]} -eq 0 ]] ; then
   echo "https://i.kym-cdn.com/photos/images/newsfeed/001/240/075/90f.png"
   exit 1
 fi
-
-# Copy patch and README file to tmp directory for use after checkout.
-echo "Copying decoupledpatch and decoupled-README to /tmp for use later."
-cp devops/scripts/decoupledpatch.sh /tmp/decoupledpatch.sh
-cp devops/files/decoupled-README.md /tmp/decoupled-README.md
 
 # Cherry-pick commits not modifying circle config onto the release branch
 git checkout -b decoupled --track decoupled/main


### PR DESCRIPTION
After testing, I'm fairly certain the reason our [decoupled upstream](https://github.com/pantheon-upstreams/decoupled-wordpress-composer-managed) isn't receiving updates is because the `deploy-public-upstream` job uses the same `release-pointer` tag in both repo steps. At the end of the `Copy commits to destination repo` step, the `release-pointer` tag is updated, and then the `Run decoupledpatch.sh and copy commits to decoupled destination repo` step runs and checks against the updated tag (always resulting in `No new commits found to release`).

This PR points the decoupled step towards its own tag, `decoupled-release-pointer`, which matches the most recent commit in the [upstream](https://github.com/pantheon-upstreams/decoupled-wordpress-composer-managed/commits/main).

Additionally, the devops directory does not exist in the decoupled upstream and we need to copy a few of these files to a temp directory before checking out that repo ([related test failure](https://app.circleci.com/pipelines/github/pantheon-systems/wordpress-composer-managed/168/workflows/6da88cb4-f32b-4af0-9295-f56f50050cc0/jobs/191)).