### PR TITLE
Change from php_version to php-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php_version: ['7.4', '8.0', '8.1']
+        php-version: ['7.4', '8.0', '8.1']
 
     steps:
     - uses: actions/checkout@v2
@@ -15,7 +15,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php_version: ${{ matrix.php_version }}
+        php-version: ${{ matrix.php-version }}
 
     - name: Cache Composer dependencies
       id: composer-cache


### PR DESCRIPTION
This repeats the change made by the Bedrock project in roots/bedrock#650 , making it so that the matrix of PHP versions is run as expected.