### PR TITLE
[CMS-1106] Additional Lando configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # Be sure to replace YOUR-LOCAL-DOMAIN below too.
 
 WP_HOME='YOUR-LOCAL-DOMAIN'
-WP_SITEURL="${WP_HOME}/wp"
+WP_SITEURL="YOUR-LOCAL-DOMAIN/wp"
 WP_ENV='development'
 
 DB_NAME=$_ENV['DB_NAME']

--- a/config/application.php
+++ b/config/application.php
@@ -36,7 +36,12 @@ $env_files = file_exists($root_dir . '/.env.local')
     : ['.env', '.env.pantheon'];
 
 $dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, $env_files, false);
-if (file_exists($root_dir . '/.env')) {
+if (
+    // Check if a .env file exists.
+    file_exists($root_dir . '/.env') ||
+    // Also check if we're using Lando and a .env.local file exists.
+    ( file_exists($root_dir . '/.env.local') && 'lando' === $_ENV['PANTHEON_ENVIRONMENT'] )
+) {
     $dotenv->load();
     if (!env('DATABASE_URL')) {
         $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);


### PR DESCRIPTION
This PR makes two changes for Lando local behavior and solves the issue described in CMS-1106 (local WordPress Composer Managed sites can't login on Lando).

* Adds an additional check for `.env.local` when a `lando` `PANTHEON_ENVIRONMENT` exists
* Updates the `.env.example` to use current Lando standards for the `.env` constant used for `WP_SITEURL` (see: https://docs.lando.dev/config/env.html#environment-files)