### PR TITLE
Ignore .github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Change from `php_version` to `php-version` in testing matrix ([#46](https://github.com/pantheon-systems/wordpress-composer-managed/pull/46))
 * Additional Lando configuration ([#47](https://github.com/pantheon-systems/wordpress-composer-managed/pull/47))
 * Fix a typo in `README-internal.md` ([#48](https://github.com/pantheon-systems/wordpress-composer-managed/pull/48))
+* Exclude `.github/` from the deploy script for the upstream repository. ([#50](https://github.com/pantheon-systems/wordpress-composer-managed/pull/50))
 
 ### 2022-10-17
 * Load global .env file even if .env.local is absent ([#32](https://github.com/pantheon-systems/wordpress-composer-managed/pull/32))

--- a/devops/scripts/commit-type.sh
+++ b/devops/scripts/commit-type.sh
@@ -11,7 +11,7 @@ function identify_commit_type() {
 
   affected_paths=$(git show "${commit}" --pretty=oneline --name-only | tail -n +2)
   for path in $affected_paths; do
-      if [[ $path =~ ^.circleci/ || $path =~ ^devops/ || $path == "README-internal.md" ]] ; then
+      if [[ $path =~ ^.circleci/ || $path =~ ^.github/ || $path =~ ^devops/ || $path == "README-internal.md" ]] ; then
         has_nonrelease_changes=1
         continue
       fi


### PR DESCRIPTION
We don't want or need to push `.github` to the upstream repo. Currently, changes to `.github/workflows/ci.yml` are causing a merge conflict with our deploy script to push to the upstream. We shouldn't be adding these files, so add to the list of excluded paths.