### PR TITLE
[CMS-1128] composer updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,15 @@ web/app/cache/*
 web/wp
 web/.htaccess
 
+# Our Composer post-install command creates a symbollic link to web/wp inside
+# web. We don't want to version control these linked files, so we ignore them
+# explicitly.
+web/license.txt
+web/readme.html
+web/index.php
+web/wp-*
+web/xmlrpc.php
+
 # Logfiles should always be ignored.
 *.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ web/app/cache/*
 web/wp
 web/.htaccess
 
-# Our Composer post-install command creates a symbollic link to web/wp inside
+# Our Composer post-install command creates a symbolic link to web/wp inside
 # web. We don't want to version control these linked files, so we ignore them
 # explicitly.
 web/license.txt

--- a/composer.json
+++ b/composer.json
@@ -108,11 +108,15 @@
     "post-root-package-install": [
       "php -r \"copy('.env.example', '.env');\""
     ],
-    "test": [
-      "phpcs"
+    "post-install-cmd": [
+      "cd web; ln-s wp/* . || true",
+      "rm web/wp-settings.php"
     ],
     "pre-update-cmd": [
-        "WordPressComposerManaged\\ComposerScripts::preUpdate"
+      "WordPressComposerManaged\\ComposerScripts::preUpdate"
+    ],
+    "test": [
+      "phpcs"
     ],
     "upstream-require": [
         "WordPressComposerManaged\\ComposerScripts::upstreamRequire"

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
       "php -r \"copy('.env.example', '.env');\""
     ],
     "post-install-cmd": [
-      "cd web; ln-s wp/* . || true",
+      "cd web; ln -s wp/* . || true",
       "rm web/wp-settings.php"
     ],
     "pre-update-cmd": [


### PR DESCRIPTION
This PR adds the changes suggested in CMS-1128, specifically:

* adds a `post-install-cmd` script to symlink the `web/wp` directory into `web` (except `wp-settings.php`) when running `composer install`
* gitignores the symlinked files

This PR also moves the test script down so the Composer-specific hooks are grouped together.