### PR TITLE
Roots Sage install script & repository maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Remove Dependabot ([#58](https://github.com/pantheon-systems/wordpress-composer-managed/pull/58))
 * Resolves issue where updates to commit choosing logic were causing a merge conflict. ([#60](https://github.com/pantheon-systems/wordpress-composer-managed/pull/60))
 * Adds a Roots Sage install script. See [docs/Installing-Sage.md](docs/Installing-Sage.md) ([#61](https://github.com/pantheon-systems/wordpress-composer-managed/pull/61))
+* Updates the SSH key fingerprint in CircleCI config ([#63](https://github.com/pantheon-systems/wordpress-composer-managed/pull/63))
 
 ### 2022-11-30
 * Set minimum-stability to "stable" in `composer.json` ([#55](https://github.com/pantheon-systems/wordpress-composer-managed/pull/55))


### PR DESCRIPTION
This update adds an install script (located in /private/scripts and accessible via Composer) that can assist in installing the Roots Sage theme on new WordPress (Composer Managed) sites. Documentation can be found in the README.md file and in the Installing Sage doc in /docs.

This update also disables the Dependabot dependency management notifications (we do not want to change the versions of dependencies in our composer.json file for risk of merge
conflicts).

Finally, this update resolves an issue that was causing releases to not deploy to the Decoupled WordPress (Composer Managed) upstream.