### PR TITLE
DB-5248: add composer patches plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
     "pantheon-upstreams/upstream-configuration": "dev-main",
     "wpackagist-plugin/lh-hsts": "^1.25",
     "wpackagist-plugin/pantheon-advanced-page-cache": "*",
-    "wpackagist-plugin/wp-native-php-sessions": "*"
+    "wpackagist-plugin/wp-native-php-sessions": "*",
+    "cweagans/composer-patches": "^1.7"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.6.2",
@@ -76,7 +77,8 @@
     "process-timeout": 0,
     "allow-plugins": {
       "composer/installers": true,
-      "roots/wordpress-core-installer": true
+      "roots/wordpress-core-installer": true,
+      "cweagans/composer-patches": true
     }
   },
   "minimum-stability": "stable",
@@ -98,7 +100,8 @@
       "locations": {
         "web-root": "./"
       }
-    }
+    },
+    "enable-patching": true
   },
   "autoload": {
       "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -101,6 +101,7 @@
         "web-root": "./"
       }
     },
+    "composer-exit-on-patch-failure": true,
     "enable-patching": true
   },
   "autoload": {


### PR DESCRIPTION
We'll be introducing an upstream dependency to decoupled-wordpress-composer-managed that uses a patch. To make this possible this PR adds and configures the composer patches plugin. We'll also need these changes to be syndicated to decoupled-wordpress-composer-managed when merged.