### PR TITLE
[CMSP-220] Decoupled deploy bug

### DIFF
--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -40,7 +40,10 @@ for commit in $newcommits; do
   # Exclude commits which have been manually rejected
   skip=false
   for item in "${exclude_list[@]}"; do
-    [[ $item == $commit ]] && echo "Commit ${commit} has been manually excluded."; skip=true
+    if [[ $item == $commit ]]; then
+      echo "Commit ${commit} has been manually excluded."
+      skip=true
+    fi
   done
 
   if [[ $skip==true ]] ; then

--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -93,7 +93,7 @@ for commit in "${commits[@]}"; do
   fi
   echo "Adding $commit:"
   git --no-pager log --format=%B -n 1 "$commit"
-  git cherry-pick -rn "$commit" 2>&1
+  git cherry-pick -rn -X theirs "$commit" 2>&1
   # Product request - single commit per release
   # The commit message from the last commit will be used.
   git log --format=%B -n 1 "$commit" > /tmp/commit_message

--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -46,7 +46,7 @@ for commit in $newcommits; do
     fi
   done
 
-  if [[ $skip = true ]] ; then
+  if [[ $skip == true ]] ; then
       continue
   fi
 

--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -60,11 +60,13 @@ for commit in $newcommits; do
     echo "You may wish to ensure that nothing in this commit is meant for release."
     delete=(${commit})
     for remove in "${delete[@]}"; do
-      for i in "${commits[@]}"; do
-        if [ [ ${commits[i]} = $remove ]]; then
-          unset 'commits[i]'
-        fi
-      done
+      if (( ${#commits[@]} )); then
+        for i in "${commits[@]}"; do
+          if [[ ${commits[0]} = $remove ]]; then
+            unset 'commits[i]'
+          fi
+        done
+      fi
     done
   fi
 done

--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -46,7 +46,7 @@ for commit in $newcommits; do
     fi
   done
 
-  if [[ $skip==true ]] ; then
+  if [[ $skip = true ]] ; then
       continue
   fi
 


### PR DESCRIPTION
This PR does a few things in an effort to fix our failing decoupled deploys.

It was discovered in research that since the decoupled deploy script was initially created, successful automated decoupled deploys have never actually happened. Similarly, the `decoupled-release-pointer` has never been updated since its initial deploy. This was causing the `newcommits=$(git log ...)` command to always pull everything from August to the current HEAD.

While initially in discussing with @rwagner00 it was thought that perhaps we could simply add the commits we don't need to the `exclude_list`, ultimately I realized that the code would need to exist in the `decoupled-release-pointer` if it was to be up-to-date.

So, in addition to fixing some bash issues that were causing new commits to simply be skipped, I've also updated the `git cherry-pick` command to always accept code from `theirs`. This allows the commits to process normally without having to exclude them manually and should result in the `decoupled-release-pointer` being updated as expected.