### PR TITLE
Allow application.php edits

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -1,8 +1,5 @@
 <?php
 /**
- * IMPORTANT NOTE:
- * Do not modify this file. This file is maintained by Pantheon.
- *
  * Your base production configuration goes in this file.
  *
  * A good default policy is to deviate from the production config as little as


### PR DESCRIPTION
Our current `config/application.php` file has a warning telling customers not to make changes to it. However, Bedrock's own documentation (and the file itself) indicates that that's where you should do any of the things you would otherwise do in `wp-config.php` (which you should _not_ edit).

We should remove our note to not edit this file because we will be asking people to make changes to the file for multisite or to change their `WP_DEBUG` settings.