### PR TITLE
[BUGS-6047] Force symbolic links in composer (no clone/embed folders).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
       "php -r \"copy('.env.example', '.env');\""
     ],
     "post-install-cmd": [
-      "cd web; ln -s wp/* . || true",
+      "cd web; ln -sfn wp/* . || true",
       "rm web/wp-settings.php"
     ],
     "pre-update-cmd": [


### PR DESCRIPTION
Fixes #78 

Should **definitely** be tested within OSX.

Not sure if OSX has `-n` or not.