### PR TITLE
[BUGS-6034] sage theme script adjustment

### DIFF
--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -108,11 +108,22 @@ function get_info() {
 
 # Confirm user-submitted theme-name and ensure letters are lower-space
 function confirmThemeName() {
-  if [[ $sagename = *[[:space:]]* ]]
-  then
-      echo "Invalid theme name. Converting 'spaces' into dashes '-'."
-      sagename=$(echo "$sagename" | tr '[:space:]' '-')
-  fi
+  # Replace spaces with dashes and convert to lowercase
+  echo "Validating theme name..."
+  sagename=$(echo "$sagename" | tr '[:space:]' '-' | tr '[:upper:]' '[:lower:]')
+
+  # Replace underscores with dashes
+  sagename=${sagename//_/\-}
+
+  # Remove double dashes
+  while [[ $sagename == *--* ]]; do
+    sagename=${sagename/--/-}
+  done
+
+  # Remove trailing dash (if present)
+  sagename=${sagename%-}
+
+  echo "Theme name is: $sagename"
 }
 
 # Use terminus whoami to check if the user is logged in and exit the script if they are not.

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -111,7 +111,7 @@ function confirmThemeName() {
   if [[ $sagename = *[[:space:]]* ]]
   then
       echo "Invalid theme name. Converting 'spaces' into dashes '-'."
-      sagename=$(echo "$sagename" | tr '[ ]' '[-]')
+      sagename=$(echo "$sagename" | tr '[:space:]' '-')
   fi
 }
 

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -76,6 +76,7 @@ function get_info() {
   if [ -z "$sagename" ]; then
     echo -e "${yellow}Enter your theme name.${normal}\nThis is used to create the theme directory. As such, it should ideally be all lowercase with no spaces (hyphens or underscores recommended)\n"
     read -p "Theme name: " -r sagename
+    confirmThemeName "$sagename"
   else
     echo -e "${green}Theme name: ${sagename}${normal}"
   fi
@@ -87,7 +88,7 @@ function get_info() {
   SFTP hostname: ${sftphost}"
   read -p "Is this correct? (y/n) " -n 1 -r
   # If the user enters n, redo the prompts.
-  if [[ $REPLY =~ ^[Nn]$ ]]; then
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo -e "\nRestarting...\n"
 
     # Toggle the restarted state.
@@ -103,6 +104,15 @@ function get_info() {
 
   # Set the theme directory. Do this at the end, after we know what everything should be.
   sagedir=$themedir/$sagename
+}
+
+# Confirm user-submitted theme-name and ensure letters are lower-space
+function confirmThemeName() {
+  if [[ $sagename = *[[:space:]]* ]]
+  then
+      echo "Invalid theme name. Converting 'spaces' into dashes '-'."
+      sagename=$(echo "$sagename" | tr '[ ]' '[-]')
+  fi
 }
 
 # Use terminus whoami to check if the user is logged in and exit the script if they are not.


### PR DESCRIPTION
Fixes #72 

**Two Changes:**
1. Updated the Restart trigger to **require** "Yes" or "y", etc. instead of "Not no".
2. Added a small 'checker' function to ensure the theme-name attempting to generate is both valid and useable.

Potential additional changes which could go into the new `confirmThemeName()` function:

```bash
  echo "Ensuring lower-space letters only."
  sagename=$(echo "$sagename" | tr '[:upper:]' '[:lower:]')

  echo "Ensuring theme-names are dashes instead of underscores."
  sagename=$(echo "$sagename" | tr '_' '-')
```

Didn't include them, as it felt like more of an internal decision for Pantheon? I know there are a **lot** of variables to be considered.

That said, this would just ensure the theme name **at creation** had no underscores ( `_` ), no spaces ( ` ` ), and was lowercase.

The only scenario I can think of where you _wouldn't_ want those things on a "Best Practice" kit is where the theme itself somehow exists as a stand-alone Class, but..... I can't mentally picture that? :shrug: 