### PR TITLE
[BUGS-6035] create a new function to check jq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
     - name: Install Composer dependencies
       run: composer install --no-progress --prefer-dist --optimize-autoloader
 
+    - name: Run lints
+      run: composer lint
+
     - name: Run tests
       run: composer test

--- a/.lando.upstream.yml
+++ b/.lando.upstream.yml
@@ -1,0 +1,25 @@
+recipe: pantheon
+config:
+  framework: wordpress
+  xdebug: false
+
+events:
+  post-start:
+    - appserver: composer install
+
+services:
+  appserver:
+    build_as_root:
+      - curl -sL https://deb.nodesource.com/setup_18.x | bash -
+      - apt-get install -y nodejs
+      - npm install --global jq stylelint stylelint-no-browser-hacks stylelint-config-standard stylelint-order
+      - mkdir -p /root/tmp
+      - chmod 666 /root/tmp
+    overrides:
+      volumes:
+        - ${HOME}/.lando/composer_cache:/var/www/.composer
+
+tooling:
+  npm:
+    service: appserver
+    cmd: cd /app/web/wp-content/themes/THEME_NAME && npm

--- a/composer.json
+++ b/composer.json
@@ -124,9 +124,21 @@
     "install-sage": [
       "bash ./private/scripts/sage-theme-install.sh"
     ],
-    "test": [
+    "lint": [
+      "@lint:php",
+      "@lint:phpcs",
+      "@lint:bash"
+    ],
+    "lint:php": [
+      "php -l web/wp/wp-settings.php"
+    ],
+    "lint:phpcs": [
       "phpcs"
     ],
+    "lint:bash": [
+      "shellcheck private/scripts/*.sh"
+    ],
+    "test": [],
     "upstream-require": [
         "WordPressComposerManaged\\ComposerScripts::upstreamRequire"
     ]

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.6.2",
-    "roave/security-advisories": "dev-latest"
+    "roave/security-advisories": "dev-latest",
+    "assertwell/shellcheck": "^1.0"
   },
   "config": {
     "optimize-autoloader": true,

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -264,7 +264,7 @@ function check_jq() {
       echo '      "post-install-cmd": ['
       echo "          \"@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=web/app/themes/$sagename\""
       echo '      ],'
-      echo "${yellow}You might try running `lando composer install-sage` if you are running locally.${normal}"
+      echo "${yellow}You might try running `lando composer install-sage` if you are running locally. Alternately, you can try installing jq another way and then running the script again: https://stedolan.github.io/jq/download/${normal}"
       exit 1
     fi
   fi

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -310,7 +310,7 @@ function update_composer() {
   fi
 
   # Check for long-running workflows.
-  if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" -eq *"running"* ]]; then
+  if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" == *"running"* ]]; then
     echo -e "${yellow}Workflow still running, waiting another 30 seconds.${normal}"
     terminus workflow:wait --max=30 "$sitename".dev
   fi

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -264,7 +264,7 @@ function check_jq() {
       echo '      "post-install-cmd": ['
       echo "          \"@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=web/app/themes/$sagename\""
       echo '      ],'
-      echo "${yellow}You might try running `lando composer install-sage` if you are running locally. Alternately, you can try installing jq another way and then running the script again: https://stedolan.github.io/jq/download/${normal}"
+      echo "${yellow}You might try running 'lando composer install-sage' if you are running locally. Alternately, you can try installing jq another way and then running the script again: https://stedolan.github.io/jq/download/${normal}"
       exit 1
     fi
   fi

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -264,7 +264,7 @@ function check_jq() {
       echo '      "post-install-cmd": ['
       echo "          \"@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=web/app/themes/$sagename\""
       echo '      ],'
-      echo "${yellow}You might try running `lando composer install` if you are running locally.${normal}"
+      echo "${yellow}You might try running `lando composer install-sage` if you are running locally.${normal}"
       exit 1
     fi
   fi

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -149,7 +149,7 @@ get_field() {
   input="$(echo "$input" | sed -e '1d' -e '$d')"
   # $1: field name
   # $2: input string
-  echo "$2" | awk -v field="$1" '$1 -eq field { print $2 }'
+  echo "$2" | awk -v field="$1" '$1 == field { print $2 }'
 }
 
 # Update to PHP 8.0

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -346,20 +346,17 @@ function clean_up() {
   git pull --ff --commit
 }
 
-# Defines some global variables for colors. We don't use all of these, but we might in the future.
+# Defines some global variables for colors.
 normal=$(tput sgr0)
 bold=$(tput bold)
-# shellcheck disable=SC2034
-italic=$(tput sitm)
 red=$(tput setaf 1)
 green=$(tput setaf 2)
 yellow=$(tput setaf 3)
-# shellcheck disable=SC2034
-blue=$(tput setaf 4)
-# shellcheck disable=SC2034
-magenta=$(tput setaf 5)
-# shellcheck disable=SC2034
-cyan=$(tput setaf 6)
+# Additional styles we aren't currently using.
+#italic=$(tput sitm)
+#blue=$(tput setaf 4)
+#magenta=$(tput setaf 5)
+#cyan=$(tput setaf 6)
 
 # Check if the user is logged into Terminus before trying to run other Terminus commands.
 check_login

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -350,15 +350,19 @@ function clean_up() {
   git pull --ff --commit
 }
 
-# Defines some global variables for colors.
+# Defines some global variables for colors. We don't use all of these, but we might in the future.
 normal=$(tput sgr0)
 bold=$(tput bold)
+# shellcheck disable=SC2034
 italic=$(tput sitm)
 red=$(tput setaf 1)
 green=$(tput setaf 2)
 yellow=$(tput setaf 3)
+# shellcheck disable=SC2034
 blue=$(tput setaf 4)
+# shellcheck disable=SC2034
 magenta=$(tput setaf 5)
+# shellcheck disable=SC2034
 cyan=$(tput setaf 6)
 
 # Check if the user is logged into Terminus before trying to run other Terminus commands.

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -10,14 +10,14 @@ function get_info() {
   dashboard_link="https://dashboard.pantheon.io/sites/${id}#dev/code"
 
   # Unset the variables if we're doing this a second time.
-  if [ "$is_restarted" == 1 ]; then
+  if [ "$is_restarted" -eq 1 ]; then
     unset sitename
     unset sagename
     unset sftpuser
     unset sftphost
   fi
 
-  if [ "$is_restarted" == 0 ]; then
+  if [ "$is_restarted" -eq 0 ]; then
     echo -e "${yellow}Finding site information...${normal}\n"
   fi
 
@@ -26,22 +26,22 @@ function get_info() {
   # set them to empty strings.
   # There's some discussion about the brackets distinction in this
   # StackOverflow: https://stackoverflow.com/a/13864829/1351526
-  if [ "$is_restarted" == 0 ] && [ -z "$sitename" ]; then
+  if [ "$is_restarted" -eq 0 ] && [ -z "$sitename" ]; then
     echo "Found site name! Using ${name}."
     sitename=$name
   fi
 
-  if [ "$is_restarted" == 0 ] && [ -z "$sftpuser" ]; then
+  if [ "$is_restarted" -eq 0 ] && [ -z "$sftpuser" ]; then
     echo "Found SFTP username! Using dev.${id}."
     sftpuser=dev.$id
   fi
 
-  if [ "$is_restarted" == 0 ] && [ -z "$sftphost" ]; then
+  if [ "$is_restarted" -eq 0 ] && [ -z "$sftphost" ]; then
     echo "Found SFTP host name! Using appserver.dev.${id}.drush.in."
     sftphost=appserver.dev.$id.drush.in
   fi
 
-  if [ "$is_restarted" == 0 ]; then
+  if [ "$is_restarted" -eq 0 ]; then
     echo -e "\n--------------------------------------------------------------------------"
   fi
   # We want these to evaluate to false if they're empty strings so they can be
@@ -67,7 +67,7 @@ function get_info() {
     echo -e "${green}SFTP hostname: ${normal}${sftphost}"
   fi
 
-  if [ "$is_restarted" == 0 ]; then
+  if [ "$is_restarted" -eq 0 ]; then
     echo -e "--------------------------------------------------------------------------\n"
   fi
 
@@ -115,7 +115,7 @@ function confirmThemeName() {
   sagename=${sagename//_/\-}
 
   # Remove double dashes
-  while [[ $sagename == *--* ]]; do
+  while [[ $sagename -eq *--* ]]; do
     sagename=${sagename/--/-}
   done
 
@@ -149,7 +149,7 @@ get_field() {
   input="$(echo "$input" | sed -e '1d' -e '$d')"
   # $1: field name
   # $2: input string
-  echo "$2" | awk -v field="$1" '$1 == field { print $2 }'
+  echo "$2" | awk -v field="$1" '$1 -eq field { print $2 }'
 }
 
 # Update to PHP 8.0
@@ -310,7 +310,7 @@ function update_composer() {
   fi
 
   # Check for long-running workflows.
-  if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" == *"running"* ]]; then
+  if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" -eq *"running"* ]]; then
     echo -e "${yellow}Workflow still running, waiting another 30 seconds.${normal}"
     terminus workflow:wait --max=30 "$sitename".dev
   fi

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 # Get the site name, theme name, and SFTP credentials from the user.
@@ -11,14 +10,14 @@ function get_info() {
   dashboard_link="https://dashboard.pantheon.io/sites/${id}#dev/code"
 
   # Unset the variables if we're doing this a second time.
-  if [ $is_restarted == 1 ]; then
+  if [ "$is_restarted" == 1 ]; then
     unset sitename
     unset sagename
     unset sftpuser
     unset sftphost
   fi
 
-  if [ $is_restarted == 0 ]; then
+  if [ "$is_restarted" == 0 ]; then
     echo -e "${yellow}Finding site information...${normal}\n"
   fi
 
@@ -27,22 +26,22 @@ function get_info() {
   # set them to empty strings.
   # There's some discussion about the brackets distinction in this
   # StackOverflow: https://stackoverflow.com/a/13864829/1351526
-  if [ $is_restarted == 0 ] && [ -z "$sitename" ]; then
+  if [ "$is_restarted" == 0 ] && [ -z "$sitename" ]; then
     echo "Found site name! Using ${name}."
     sitename=$name
   fi
 
-  if [ $is_restarted == 0 ] && [ -z "$sftpuser" ]; then
+  if [ "$is_restarted" == 0 ] && [ -z "$sftpuser" ]; then
     echo "Found SFTP username! Using dev.${id}."
     sftpuser=dev.$id
   fi
 
-  if [ $is_restarted == 0 ] && [ -z "$sftphost" ]; then
+  if [ "$is_restarted" == 0 ] && [ -z "$sftphost" ]; then
     echo "Found SFTP host name! Using appserver.dev.${id}.drush.in."
     sftphost=appserver.dev.$id.drush.in
   fi
 
-  if [ $is_restarted == 0 ]; then
+  if [ "$is_restarted" == 0 ]; then
     echo -e "\n--------------------------------------------------------------------------"
   fi
   # We want these to evaluate to false if they're empty strings so they can be
@@ -68,7 +67,7 @@ function get_info() {
     echo -e "${green}SFTP hostname: ${normal}${sftphost}"
   fi
 
-  if [ $is_restarted == 0 ]; then
+  if [ "$is_restarted" == 0 ]; then
     echo -e "--------------------------------------------------------------------------\n"
   fi
 
@@ -144,7 +143,7 @@ function check_login() {
 get_field() {
   local input="$1"
   # Remove leading and trailing whitespace from each line
-  input="$(echo "$input" | sed -e 's/^[ \t]*//')"
+  input="${input#"${input%%[![:space:]]*}"}"
 
   # Remove the first and last lines that are entirely dashes
   input="$(echo "$input" | sed -e '1d' -e '$d')"
@@ -158,8 +157,8 @@ function update_php() {
   echo -e "\n\n${yellow}Updating PHP version to 8.0.${normal}"
 
   # Testing for any version of PHP 8.x and/or PHP 7.4.
-  phpAlreadyVersion8=$(cat pantheon.yml | grep -c "php_version: 8.")
-  phpDeclaredInFile=$(cat pantheon.yml | grep -c "php_version: 7.4")
+  phpAlreadyVersion8=$(grep -c "php_version: 8." < pantheon.yml)
+  phpDeclaredInFile=$(grep -c "php_version: 7.4" < pantheon.yml)
 
   # Only alter if not already PHP 8.x.
   if [ "$phpAlreadyVersion8" -eq 0 ]; then
@@ -182,30 +181,30 @@ function install_sage() {
   # Check if the directory $sagedir is empty. If it's not, bail.
   echo -e "Checking if ${sagedir} is exists and if it's empty.\n"
 
-  if [ "$(ls -A $sagedir)" ]; then
+  if [ "$(ls -A "$sagedir")" ]; then
     echo -e "${red}Directory not empty!${normal}\n Trying to install into ${sagedir}. Exiting."
     exit 1;
   fi
 
   echo -e "${yellow}Installing Sage.${normal}"
   # Create the new Sage theme
-  composer create-project roots/sage $sagedir
+  composer create-project roots/sage "$sagedir"
 
   # Require Roots/acorn
-  composer require roots/acorn --working-dir=$sagedir
+  composer require roots/acorn --working-dir="$sagedir"
 
   # Install all the Sage dependencies
-  composer install --no-dev --prefer-dist --working-dir=$sagedir
+  composer install --no-dev --prefer-dist --working-dir="$sagedir"
 
   # NPM the things
-  npm install --prefix $sagedir
-  npm run build --prefix $sagedir
+  npm install --prefix "$sagedir"
+  npm run build --prefix "$sagedir"
 
   # Remove /public from .gitignore
-  sed -i '' "s/\/public//" $sagedir/.gitignore
+  sed -i '' "s/\/public//" "$sagedir"/.gitignore
 
   # Commit the theme
-  git add $sagedir
+  git add "$sagedir"
   git commit -m "[Sage Install] Add the Sage theme ${sagename}."
   git push origin master
   echo -e "${green}Sage installed!${normal}\n"
@@ -214,7 +213,7 @@ function install_sage() {
 # Create the symlink to the cache directory.
 function add_symlink() {
   # Switch to SFTP mode
-  terminus connection:set $sitename.dev sftp
+  terminus connection:set "$sitename".dev sftp
 
   if [ ! -d "web/app/uploads" ]; then
     echo -e "${yellow}Creating the uploads directory.${normal}"
@@ -227,18 +226,18 @@ function add_symlink() {
   fi
 
   # Create a files/cache directory on the host.
-  sftp -P 2222 $sftpuser@$sftphost <<EOF
+  sftp -P 2222 "$sftpuser"@"$sftphost" <<EOF
     cd /files
     mkdir cache
 EOF
 
     # Switch back to Git mode.
-    terminus connection:set $sitename.dev git
+    terminus connection:set "$sitename".dev git
 
   # Create the symlink to /files/cache.
-  cd web/app
+  cd web/app || return
   echo -e "${yellow}Adding a symlink to the cache directory.${normal}"
-  ln -sfn uploads/cache
+  ln -sfn uploads/cache .
   git add .
   git commit -m "[Sage Install] Add a symlink for /files/cache to /uploads/cache"
   git push origin master
@@ -248,18 +247,18 @@ EOF
 # Check if jq is installed. If it's not, try a couple ways of installing it.
 function check_jq() {
   # Check if jq is installed.
-  if [ ! command -v jq &> /dev/null ]; then
+  if ! command -v jq &> /dev/null; then
     echo -e "${yellow}jq is not installed.${normal}"
     # Check if brew is installed.
-    if [ command -v brew &> /dev/null ]; then
+    if command -v brew &> /dev/null; then
       echo -e "${yellow}Installing jq with Homebrew.${normal}"
       brew install jq
     # Check if apt-get is installed.
-    elif [ command -v apt-get &> /dev/null ]; then
+    elif command -v apt-get &> /dev/null; then
       echo -e "${yellow}Installing jq with apt-get.${normal}"
       sudo apt-get install -y jq
     else
-      echo "${yellow}Attempted to install jq but could not find Brew (for MacOS) or apt-get (for WSL2/Linux). Exiting here. You'll need to add the following lines to your `composer.json`:${normal}"
+      echo "${yellow}Attempted to install jq but could not find Brew (for MacOS) or apt-get (for WSL2/Linux). Exiting here. You'll need to add the following lines to your composer.json:${normal}"
       echo '  "scripts": {'
       echo '      "post-install-cmd": ['
       echo "          \"@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=web/app/themes/$sagename\""
@@ -298,55 +297,52 @@ function update_composer() {
   git commit -m "[Sage Install] Add post-install-cmd hook to also run install on ${sagename}"
 
   git pull --ff --commit
-  git push origin master
-  if [ $? -ne 0 ]; then
+  if ! git push origin master; then
     echo -e "\n${red}Push failed. Stopping here.${normal}\nNext steps are to push the changes to the repo and then set the connection mode back to Git."
     exit 1;
   fi
 
   # Wait for the build to finish.
   echo -e "${yellow}Waiting for the deploy to finish.${normal}"
-  terminus workflow:wait --max=30 $sitename.dev
-  if [ $? -ne 0 ]; then
+  if ! terminus workflow:wait --max=30 "$sitename".dev; then
     echo -e "\n${red}terminus workflow:wait command not found. Stopping here.${normal}\nYou will need to install the terminus-build-tools-plugin.\nterminus self:plugin:install terminus-build-tools-plugin"
     exit 1;
   fi
 
   # Check for long-running workflows.
-  if [[ "$(terminus workflow:wait --max=1 ${sitename}.dev)" == *"running"* ]]; then
+  if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" == *"running"* ]]; then
     echo -e "${yellow}Workflow still running, waiting another 30 seconds.${normal}"
-    terminus workflow:wait --max=30 $sitename.dev
+    terminus workflow:wait --max=30 "$sitename".dev
   fi
 }
 
 # Finish up the Sage install process.
 function clean_up() {
   # If the site is multisite, we'll need to enable the theme so we can activate it.
-  terminus wp -- $sitename.dev theme enable $sagename
+  terminus wp -- "$sitename".dev theme enable "$sagename"
   # List the themes.
-  terminus wp -- $sitename.dev theme list
+  terminus wp -- "$sitename".dev theme list
 
   # Activate the new theme
   echo -e "${yellow}Activating the ${sagename} theme.${normal}"
-  terminus wp -- $sitename.dev theme activate $sagename
-  if [ $? -ne 0 ]; then
+  if ! terminus wp -- "$sitename".dev theme activate "$sagename"; then
     echo -e "${red}Theme activation failed. Exiting here.${normal}\nCheck the theme list above. If the theme you created is not listed, it's possible that the deploy has not completed. You can try again in a few minutes using the following command:\nterminus wp -- $sitename.dev theme activate $sagename\nOnce you do this, you will need to open the site to generate the requisite files and then commit them in SFTP mode.\n5. You're ready to go! Set the connection mode back to Git."
     exit 1;
   fi
 
   # Switch back to SFTP so files can be written.
-  terminus connection:set $sitename.dev sftp
+  terminus connection:set "$sitename".dev sftp
 
   # Open the site. This should generate requisite files on page load.
   echo -e "${yellow}Opening the dev-${sitename}.pantheonsite.io to generate requisite files.${normal}"
-  open https://dev-$sitename.pantheonsite.io
+  open https://dev-"$sitename".pantheonsite.io
 
   # Commit any additions found in SFTP mode.
   echo -e "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
-  terminus env:commit $sitename.dev --message="[Sage Install] Add any leftover files found in SFTP mode."
+  terminus env:commit "$sitename".dev --message="[Sage Install] Add any leftover files found in SFTP mode."
 
   # Switch back to Git.
-  terminus connection:set $sitename.dev git
+  terminus connection:set "$sitename".dev git
   git pull --ff --commit
 }
 

--- a/private/scripts/sage-theme-install.sh
+++ b/private/scripts/sage-theme-install.sh
@@ -245,28 +245,32 @@ EOF
 }
 
 # Check if jq is installed. If it's not, try a couple ways of installing it.
+# Check if jq is installed. If it's not, try a couple ways of installing it.
 function check_jq() {
-  # Check if jq is installed.
-  if ! command -v jq &> /dev/null; then
-    echo -e "${yellow}jq is not installed.${normal}"
-    # Check if brew is installed.
-    if command -v brew &> /dev/null; then
-      echo -e "${yellow}Installing jq with Homebrew.${normal}"
-      brew install jq
-    # Check if apt-get is installed.
-    elif command -v apt-get &> /dev/null; then
-      echo -e "${yellow}Installing jq with apt-get.${normal}"
-      sudo apt-get install -y jq
-    else
-      echo "${yellow}Attempted to install jq but could not find Brew (for MacOS) or apt-get (for WSL2/Linux). Exiting here. You'll need to add the following lines to your composer.json:${normal}"
-      echo '  "scripts": {'
-      echo '      "post-install-cmd": ['
-      echo "          \"@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=web/app/themes/$sagename\""
-      echo '      ],'
-      echo "${yellow}You might try running 'lando composer install-sage' if you are running locally. Alternately, you can try installing jq another way and then running the script again: https://stedolan.github.io/jq/download/${normal}"
-      exit 1
-    fi
+  # Check if jq is already installed.
+  if command -v jq &> /dev/null; then
+      return # jq is already installed
   fi
+  echo -e "${yellow}jq is not installed.${normal}"
+  # Check if brew is installed and install jq with it
+  if command -v brew &> /dev/null; then
+    echo -e "${yellow}Installing jq with Homebrew.${normal}"
+    brew install jq
+    return
+  fi
+  # Check if apt-get is installed and install jq with it
+  if command -v apt-get &> /dev/null; then
+    echo -e "${yellow}Installing jq with apt-get.${normal}"
+    sudo apt-get install -y jq
+    return
+  fi
+  echo "${yellow}Attempted to install jq but could not find Brew (for MacOS) or apt-get (for WSL2/Linux). Exiting here. You'll need to add the following lines to your composer.json:${normal}"
+  echo '  "scripts": {'
+  echo '      "post-install-cmd": ['
+  echo "          \"@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=web/app/themes/$sagename\""
+  echo '      ],'
+  echo "${yellow}You might try running 'lando composer install-sage' if you are running locally. Alternately, you can try installing jq another way and then running the script again: https://stedolan.github.io/jq/download/${normal}"
+  exit 1
 }
 
 # Add a post-install hook to the composer.json.


### PR DESCRIPTION
if jq doesn't exist, look for brew or apt-get. if neither of those exist, exit hard (but provide a link to downloading jq and possible next steps).

This PR pulls in #83 which adds a `.lando.upstream.yml` to handle runs inside Lando.

Also adds shellcheck for linting the Sage Install script and runs it in GH actions.

**Note:** Shellchecking the scripts in [`devops/scripts`](https://github.com/pantheon-systems/wordpress-composer-managed/tree/default/devops/scripts) is tracked in CMSP-291 and out of scope for this PR.
Fixes #73