### PR TITLE
[HOTFIX] Fix failing site builds.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
       "php -r \"copy('.env.example', '.env');\""
     ],
     "post-install-cmd": [
-      "cd web; ln -sfn wp/* . || true",
+      "cd web; ln -sfn $(ls wp/* | grep -v 'index.php') . || true",
       "rm web/wp-settings.php"
     ],
     "pre-update-cmd": [


### PR DESCRIPTION
This PR carves out an exception to the index.php file in post install.

Our post-install command was updated to create hard symlinks to the contents of the web/wp directory. We do not want this for the index.php file which is modified to point to /wp/