### PR TITLE
restore post-install-cmd to what it was originally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
       "php -r \"copy('.env.example', '.env');\""
     ],
     "post-install-cmd": [
-      "cd web; ln -sfn $(ls wp/* | grep -v 'index.php') . || true",
+      "cd web; ln -s wp/* . || true",
       "rm web/wp-settings.php"
     ],
     "pre-update-cmd": [


### PR DESCRIPTION
Builds are still failing, now because too many files are being affected by the post-install-cmd. Reverting the `ln -s` to what it was originally.