### PR TITLE
Backport Bedrock updates

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -114,7 +114,7 @@ Config::define('DISALLOW_FILE_EDIT', true);
 // Disable plugin and theme updates and installation from the admin
 Config::define('DISALLOW_FILE_MODS', true);
 // Limit the number of post revisions that Wordpress stores (true (default WP): store every revision)
-Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?: true);
+Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?? true);
 
 /**
  * Debugging Settings


### PR DESCRIPTION
There's only really one relevant update to Roots/Bedrock that we don't address in some way or other in our fork, which is [this change](https://github.com/roots/bedrock/pull/658) to the ternary definition of the `WP_POST_REVISIONS` constant to a null coalesce.  