### PR TITLE
[BUGS-6007] remove the lh-hsts plugin requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
     "wpackagist-theme/twentytwentytwo": "^1.2",
     "pantheon-systems/pantheon-mu-plugin": "*",
     "pantheon-upstreams/upstream-configuration": "dev-main",
-    "wpackagist-plugin/lh-hsts": "^1.25",
     "wpackagist-plugin/pantheon-advanced-page-cache": "*",
     "wpackagist-plugin/wp-native-php-sessions": "*",
     "cweagans/composer-patches": "^1.7"


### PR DESCRIPTION
Removes the `lh-hsts` plugin from the list of required packages. This is inherited from the original (dperecated) [Example WordPress Composer](https://github.com/pantheon-systems/example-wordpress-composer/blob/master/composer.json#L23) repository but causes a conflict with hsts defined in `pantheon.yml`.

See https://docs.pantheon.io/pantheon-yml#enforce-https--hsts