### PR TITLE
Refactor how we handle "mixed" commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2023-05-22
+### 2023-05-23
 * Removes the `lh-hsts` plugin requirement from the `composer.json` file. ([#91](https://github.com/pantheon-systems/wordpress-composer-managed/pull/91))
 * Adds the [Pantheon WP Coding Standards](https://github.com/pantheon-systems/pantheon-wp-coding-standards) to use instead of the default PHPCS/WPCS standards ([#94](https://github.com/pantheon-systems/wordpress-composer-managed/pull/94))
 * Backports updates from Roots/Bedrock ([#90](https://github.com/pantheon-systems/wordpress-composer-managed/pull/90))

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -39,7 +39,6 @@ for commit in $newcommits; do
   if [[ $commit_type == "mixed" ]] ; then
     2>&1 echo "Commit ${commit} contains both release and nonrelease changes. Skipping this commit."
     echo "You may wish to ensure that nothing in this commit is meant for release."
-    continue
   fi
 done
 

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -33,19 +33,13 @@ for commit in $newcommits; do
   commit_type=$(identify_commit_type "$commit")
   if [[ $commit_type == "normal" ]] ; then
     commits+=($commit)
+    continue
   fi
 
   if [[ $commit_type == "mixed" ]] ; then
     2>&1 echo "Commit ${commit} contains both release and nonrelease changes. Skipping this commit."
     echo "You may wish to ensure that nothing in this commit is meant for release."
-    delete=(${commit})
-    for remove in "${delete[@]}"; do
-      for i in "${commits[@]}"; do
-        if [[ ${commits[$i]} == "$remove" ]]; then
-          unset 'commits[i]'
-        fi
-      done
-    done
+    continue
   fi
 done
 


### PR DESCRIPTION
Removes a bunch of failing code handling "mixed" commits that wasn't actually running except when it was failing and breaking things anyway.

"Mixed" commits fail the checks run on PRs, appropriately, and this code was never actually adding those commits to the array of commits to deploy. It was built to solve a problem where mixed commits would fail the deploy process, which we wanted to avoid. If the goal was "skipping" the commit, the way we can do that is just not adding it to the array of commits to deploy.