### PR TITLE
remove comma in forbidden_files array

### DIFF
--- a/devops/scripts/commit-type.sh
+++ b/devops/scripts/commit-type.sh
@@ -35,7 +35,7 @@ function identify_commit_type() {
 # Verifies that the given commit does not contain forbidden files.
 function only_allowed_files() {
   local commit=$1
-  local forbidden_files=("composer.lock",".github/workflows/ci.yml")
+  local forbidden_files=("composer.lock" ".github/workflows/ci.yml")
   local has_forbidden_files=0
 
   affected_paths=$(git show "${commit}" --pretty=oneline --name-only | tail -n +2)


### PR DESCRIPTION
Commas are not how you separate elements in an array in bash.

This led to the `composer.lock` file being committed to the repository and released by mistake.