### PR TITLE
Add readme for Upstream Configuration path repository

### DIFF
--- a/upstream-configuration/README.md
+++ b/upstream-configuration/README.md
@@ -1,0 +1,11 @@
+# Upstream Configuration
+
+If you are working on your custom upstream, use this folder for upstream specific stuff.
+
+You can require the `pantheon-systems/upstream-management` [composer package](https://packagist.org/packages/pantheon-systems/upstream-management) to get access to some upstream management tools. Require it with composer like this:
+
+```
+composer require pantheon-systems/upstream-management:^1
+```
+
+Read project description for more information about the tools that it contains.


### PR DESCRIPTION
This is copy pasta from Drupal Composer Managed. While the same changes were made to WordPress Composer Managed (in terms of the `upstream-require` script), the readme was not moved over.