### PR TITLE
[CMSP-660] Update to use Pantheon-WP-Coding-Standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
       "php -l web/wp/wp-settings.php"
     ],
     "lint:phpcs": [
-      "phpcs"
+      "vendor/bin/phpcs -s ."
     ],
     "lint:bash": [
       "shellcheck private/scripts/*.sh"

--- a/config/application.php
+++ b/config/application.php
@@ -15,7 +15,7 @@ use function Env\env;
  *
  * @var string
  */
-$root_dir = dirname(__DIR__);
+$root_dir = dirname( __DIR__ );
 
 /**
  * Document Root
@@ -28,114 +28,114 @@ $webroot_dir = $root_dir . '/web';
  * Use Dotenv to set required environment variables and load .env file in root
  * .env.local will override .env if it exists
  */
-$env_files = file_exists($root_dir . '/.env.local')
-    ? ['.env', '.env.pantheon', '.env.local']
-    : ['.env', '.env.pantheon'];
+$env_files = file_exists( $root_dir . '/.env.local' )
+	? [ '.env', '.env.pantheon', '.env.local' ]
+	: [ '.env', '.env.pantheon' ];
 
-$dotenv = Dotenv\Dotenv::createUnsafeImmutable($root_dir, $env_files, false);
+$dotenv = Dotenv\Dotenv::createUnsafeImmutable( $root_dir, $env_files, false );
 if (
-    // Check if a .env file exists.
-    file_exists($root_dir . '/.env') ||
-    // Also check if we're using Lando and a .env.local file exists.
-    ( file_exists($root_dir . '/.env.local') && 'lando' === $_ENV['PANTHEON_ENVIRONMENT'] )
+	// Check if a .env file exists.
+	file_exists( $root_dir . '/.env' ) ||
+	// Also check if we're using Lando and a .env.local file exists.
+	( file_exists( $root_dir . '/.env.local' ) && 'lando' === $_ENV['PANTHEON_ENVIRONMENT'] )
 ) {
-    $dotenv->load();
-    if (!env('DATABASE_URL')) {
-        $dotenv->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD']);
-    }
+	$dotenv->load();
+	if ( ! env( 'DATABASE_URL' ) ) {
+		$dotenv->required( [ 'DB_NAME', 'DB_USER', 'DB_PASSWORD' ] );
+	}
 }
 
 /**
  * Set up our global environment constant and load its config first
  * Default: production
  */
-define('WP_ENV', env('WP_ENV') ?: 'production');
+define( 'WP_ENV', env( 'WP_ENV' ) ?: 'production' );
 
 /**
  * DB settings
  */
-Config::define('DB_NAME', env('DB_NAME'));
-Config::define('DB_USER', env('DB_USER'));
-Config::define('DB_PASSWORD', env('DB_PASSWORD'));
-Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
-Config::define('DB_CHARSET', 'utf8mb4');
-Config::define('DB_COLLATE', '');
-$table_prefix = env('DB_PREFIX') ?: 'wp_';
+Config::define( 'DB_NAME', env( 'DB_NAME' ) );
+Config::define( 'DB_USER', env( 'DB_USER' ) );
+Config::define( 'DB_PASSWORD', env( 'DB_PASSWORD' ) );
+Config::define( 'DB_HOST', env( 'DB_HOST' ) ?: 'localhost' );
+Config::define( 'DB_CHARSET', 'utf8mb4' );
+Config::define( 'DB_COLLATE', '' );
+$table_prefix = env( 'DB_PREFIX' ) ?: 'wp_';
 
-if (env('DATABASE_URL')) {
-    $dsn = (object) parse_url(env('DATABASE_URL'));
+if ( env( 'DATABASE_URL' ) ) {
+	$dsn = (object) parse_url( env( 'DATABASE_URL' ) );
 
-    Config::define('DB_NAME', substr($dsn->path, 1));
-    Config::define('DB_USER', $dsn->user);
-    Config::define('DB_PASSWORD', isset($dsn->pass) ? $dsn->pass : null);
-    Config::define('DB_HOST', isset($dsn->port) ? "{$dsn->host}:{$dsn->port}" : $dsn->host);
+	Config::define( 'DB_NAME', substr( $dsn->path, 1 ) );
+	Config::define( 'DB_USER', $dsn->user );
+	Config::define( 'DB_PASSWORD', isset( $dsn->pass ) ? $dsn->pass : null );
+	Config::define( 'DB_HOST', isset( $dsn->port ) ? "{$dsn->host}:{$dsn->port}" : $dsn->host );
 }
 
 /**
  * Pantheon modifications
  */
-if (isset($_ENV['PANTHEON_ENVIRONMENT']) && 'lando' !== $_ENV['PANTHEON_ENVIRONMENT']) {
-    Config::define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT']);
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && 'lando' !== $_ENV['PANTHEON_ENVIRONMENT'] ) {
+	Config::define( 'DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT'] );
 } else {
-    /**
-     * URLs
-     */
-    Config::define('WP_HOME', env('WP_HOME'));
-    Config::define('WP_SITEURL', env('WP_SITEURL'));
-    Config::define('DB_HOST', env('DB_HOST') ?: 'localhost');
-    Config::define('DISABLE_WP_CRON', env('DISABLE_WP_CRON') ?: false);
+	/**
+	 * URLs
+	 */
+	Config::define( 'WP_HOME', env( 'WP_HOME' ) );
+	Config::define( 'WP_SITEURL', env( 'WP_SITEURL' ) );
+	Config::define( 'DB_HOST', env( 'DB_HOST' ) ?: 'localhost' );
+	Config::define( 'DISABLE_WP_CRON', env( 'DISABLE_WP_CRON' ) ?: false );
 }
 
 /**
  * Custom Content Directory
  */
-Config::define('CONTENT_DIR', '/app');
-Config::define('WP_CONTENT_DIR', $webroot_dir . Config::get('CONTENT_DIR'));
-Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
+Config::define( 'CONTENT_DIR', '/app' );
+Config::define( 'WP_CONTENT_DIR', $webroot_dir . Config::get( 'CONTENT_DIR' ) );
+Config::define( 'WP_CONTENT_URL', Config::get( 'WP_HOME' ) . Config::get( 'CONTENT_DIR' ) );
 
 /**
  * Authentication Unique Keys and Salts
  */
-Config::define('AUTH_KEY', env('AUTH_KEY'));
-Config::define('SECURE_AUTH_KEY', env('SECURE_AUTH_KEY'));
-Config::define('LOGGED_IN_KEY', env('LOGGED_IN_KEY'));
-Config::define('NONCE_KEY', env('NONCE_KEY'));
-Config::define('AUTH_SALT', env('AUTH_SALT'));
-Config::define('SECURE_AUTH_SALT', env('SECURE_AUTH_SALT'));
-Config::define('LOGGED_IN_SALT', env('LOGGED_IN_SALT'));
-Config::define('NONCE_SALT', env('NONCE_SALT'));
+Config::define( 'AUTH_KEY', env( 'AUTH_KEY' ) );
+Config::define( 'SECURE_AUTH_KEY', env( 'SECURE_AUTH_KEY' ) );
+Config::define( 'LOGGED_IN_KEY', env( 'LOGGED_IN_KEY' ) );
+Config::define( 'NONCE_KEY', env( 'NONCE_KEY' ) );
+Config::define( 'AUTH_SALT', env( 'AUTH_SALT' ) );
+Config::define( 'SECURE_AUTH_SALT', env( 'SECURE_AUTH_SALT' ) );
+Config::define( 'LOGGED_IN_SALT', env( 'LOGGED_IN_SALT' ) );
+Config::define( 'NONCE_SALT', env( 'NONCE_SALT' ) );
 
 /**
  * Custom Settings
  */
-Config::define('AUTOMATIC_UPDATER_DISABLED', true);
-// Disable the plugin and theme file editor in the admin
-Config::define('DISALLOW_FILE_EDIT', true);
-// Disable plugin and theme updates and installation from the admin
-Config::define('DISALLOW_FILE_MODS', true);
-// Limit the number of post revisions that Wordpress stores (true (default WP): store every revision)
-Config::define('WP_POST_REVISIONS', env('WP_POST_REVISIONS') ?? true);
+Config::define( 'AUTOMATIC_UPDATER_DISABLED', true );
+// Disable the plugin and theme file editor in the admin.
+Config::define( 'DISALLOW_FILE_EDIT', true );
+// Disable plugin and theme updates and installation from the admin.
+Config::define( 'DISALLOW_FILE_MODS', true );
+// Limit the number of post revisions that Wordpress stores (true (default WP): store every revision).
+Config::define( 'WP_POST_REVISIONS', env( 'WP_POST_REVISIONS' ) ?? true );
 
 /**
  * Debugging Settings
  */
-Config::define('WP_DEBUG_DISPLAY', false);
-Config::define('WP_DEBUG_LOG', false);
-Config::define('SCRIPT_DEBUG', false);
-ini_set('display_errors', '0');
+Config::define( 'WP_DEBUG_DISPLAY', false );
+Config::define( 'WP_DEBUG_LOG', false );
+Config::define( 'SCRIPT_DEBUG', false );
+ini_set( 'display_errors', '0' );
 
 /**
  * Allow WordPress to detect HTTPS when used behind a reverse proxy or a load balancer
  * See https://codex.wordpress.org/Function_Reference/is_ssl#Notes
  */
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
-    $_SERVER['HTTPS'] = 'on';
+if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ) {
+	$_SERVER['HTTPS'] = 'on';
 }
 
 $env_config = __DIR__ . '/environments/' . WP_ENV . '.php';
 
-if (file_exists($env_config)) {
-    require_once $env_config;
+if ( file_exists( $env_config ) ) {
+	require_once $env_config;
 }
 
 Config::apply();
@@ -143,6 +143,6 @@ Config::apply();
 /**
  * Bootstrap WordPress
  */
-if (!defined('ABSPATH')) {
-    define('ABSPATH', $webroot_dir . '/wp/');
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $webroot_dir . '/wp/' );
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,6 +26,6 @@
   <!-- Show sniff codes in all reports -->
   <arg value="ns"/>
 
-  <!-- Use PSR-2 as a base -->
-  <rule ref="PSR2"/>
+  <!-- Use Pantheon-WP as a base -->
+  <rule ref="Pantheon-WP"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -20,6 +20,22 @@
   <exclude-pattern>web/app/plugins/*</exclude-pattern>
   <exclude-pattern>web/private/*</exclude-pattern>
   <exclude-pattern>upstream-configuration/*</exclude-pattern>
+
+  <!-- Ignore sniffs against things that we explicitly want for Pantheon upstreams. -->
+  <rule ref="Pantheon-WP">
+    <exclude name="WordPress.PHP.IniSet.display_errors_Disallowed">
+      <exclude-pattern>config/application.php</exclude-pattern>
+    </exclude>
+    <exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
+      <exclude-pattern>config/application.php</exclude-pattern>
+    </exclude>
+    <exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotValidated">
+      <exclude-pattern>config/application.php</exclude-pattern>
+    </exclude>
+    <exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited">
+      <exclude-pattern>config/application.php</exclude-pattern>
+    </exclude>
+  </rule>
   <!-- End Pantheon addition -->
 
   <!-- Show colors in console -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<ruleset name="Roots">
-  <description>Roots Coding Standards</description>
+<ruleset name="Pantheon WP Composer Managed">
+  <description>Pantheon WordPress Composer Managed Upstream</description>
 
   <!-- Scan all files in directory -->
   <file>.</file>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,7 @@
 
   <!-- Start Pantheon addition: Ignore plugins and quicksilver scripts -->
   <exclude-pattern>web/app/mu-plugins/*</exclude-pattern>
+  <!-- This line prevents all plugins from being linted. Remove this line if you want to lint plugins. -->
   <exclude-pattern>web/app/plugins/*</exclude-pattern>
   <exclude-pattern>web/private/*</exclude-pattern>
   <exclude-pattern>upstream-configuration/*</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,6 +26,9 @@
     <exclude name="WordPress.PHP.IniSet.display_errors_Disallowed">
       <exclude-pattern>config/application.php</exclude-pattern>
     </exclude>
+    <exclude name="WordPress.PHP.IniSet.display_errors_Blacklisted">
+      <exclude-pattern>config/application.php</exclude-pattern>
+    </exclude>
     <exclude name="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
       <exclude-pattern>config/application.php</exclude-pattern>
     </exclude>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,6 +18,7 @@
   <exclude-pattern>web/app/mu-plugins/*</exclude-pattern>
   <exclude-pattern>web/app/plugins/*</exclude-pattern>
   <exclude-pattern>web/private/*</exclude-pattern>
+  <exclude-pattern>upstream-configuration/*</exclude-pattern>
   <!-- End Pantheon addition -->
 
   <!-- Show colors in console -->


### PR DESCRIPTION
Merging is blocked until https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/pull/4 is merged.

This switches the repository to use `Pantheon-WP` as the PHPCS ruleset, rather than PSR-2 from the original Roots config.

Uses WPCS 3.0, so should not be merged until the linked issue above is merged.