### PR TITLE
Run automated test of Sage Install Script

### DIFF
--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const core = require('@actions/core');
             const pr = context.payload.number;
             core.exportVariable('PR_NUMBER', pr);
       - name: Setup PHP

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -42,7 +42,7 @@ jobs:
           esac
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          pr_num=$(echo "$PR_NUMBER")
+          pr_num=$(echo ${{ steps.pr.outputs.pull_request_number }})
           echo "PR number: $pr_num"
           echo "OS: $os_short"
           echo "PHP: $php_short"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -1,11 +1,13 @@
 name: Sage Install Tests
 on:
+  push:
+    paths:
+      - '.github/workflows/sage-test.yml'
   pull_request:
     branches:
       - main
     paths:
       - '/private/scripts/**'
-      - '/.github/workflows/sage-test.yml'
 jobs:
   test:
     name: Sage Install Tests

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -1,11 +1,11 @@
 name: Sage Install Tests
 on:
-  push:
   pull_request:
     branches:
       - main
     paths:
       - '/private/scripts/**'
+      - '/.github/workflows/sage-test.yml'
 jobs:
   test:
     name: Sage Install Tests

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -20,6 +20,13 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+      - name: Get latest Terminus release
+        run: |
+          latest_version=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | jq -r .tag_name)
+          echo "Terminus Latest version is $latest_version"
+          curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
+          chmod +x terminus
+          sudo mv terminus /usr/local/bin/
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Run Sage Install Script

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php-version: [8.0, 8.1, 8.2]
+        php-version: [8.0, 8.1, 8.2, 8.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -123,6 +123,7 @@ jobs:
           export SITENAME=wpcm-sage-install-tests
           export CI=1
           export SITEENV=$multidev_name
+          export PHPVERSION=${{ matrix.php-version }}
           cd ~/pantheon-local-copies/$SITENAME
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -141,6 +141,6 @@ jobs:
         run: |
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
           git fetch --tags origin
-          git tag -d pantheon_build_artifacts_$multidev_name
-          # Allow this to fail.
+          # Allow these to fail.
+          git tag -d pantheon_build_artifacts_$multidev_name || true
           git push origin --delete pantheon_build_artifacts_$multidev_name || true

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -55,6 +55,8 @@ jobs:
           echo "multidev_name=$multidev_name" >> $GITHUB_ENV
       - name: Get latest Terminus release
         run: |
+          latest_version=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | jq -r .tag_name)
+          echo "Latest Terminus version: $latest_version"
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             echo "☕ Installing Terminus on macOS from Homebrew..."
             brew install pantheon-systems/external/terminus

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -26,16 +26,13 @@ jobs:
         uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Get PR number
+      - name: Get and Set PR number
         id: pr
-        run: echo "pull_request_number=$(gh pr view --json number -q .number || echo '')" >> $GITHUB_OUTPUT
+        run: |
+          pr_num=$(gh pr view --json number -q .number || echo "")
+          echo "pr_num=$pr_num" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ github.token }}
-      - name: Extract PR number
-        id: extract_pr
-        run: |
-          pr_num=$(grep "pull_request_number" $GITHUB_OUTPUT | cut -d '=' -f2)
-          echo "pr_num=$pr_num" >> $GITHUB_ENV
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -45,7 +45,9 @@ jobs:
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
           pr_num=$(echo "$PR_NUMBER")
-
+          echo "PR number: $pr_num"
+          echo "OS: $os_short"
+          echo "PHP: $php_short"
           multidev_name="${os_short}-${php_short}-${pr_num}"
           echo "Generated multidev name: $multidev_name"
           echo "multidev_name=$multidev_name" >> $GITHUB_ENV

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -119,12 +119,13 @@ jobs:
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
           composer install
       - name: Run Sage Install Script
+        env:
+          SAGENAME: sage-test
+          SITENAME: wpcm-sage-install-tests
+          CI: 1
+          SITEENV: $multidev_name
+          PHPVERSION: ${{ matrix.php-version }}
         run: |
-          export SAGENAME=sage-test
-          export SITENAME=wpcm-sage-install-tests
-          export CI=1
-          export SITEENV=$multidev_name
-          export PHPVERSION=${{ matrix.php-version }}
           cd ~/pantheon-local-copies/$SITENAME
           composer install-sage
           echo "✅ Sage Install Script passed!"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -88,7 +88,7 @@ jobs:
           echo "Cloning site..."
           terminus local:clone wpcm-sage-install-tests
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
-          ls -la ~/pantheon-local-copies/wpcm-sage-install-tests
+          git diff
           # If sage-test exists, delete it.
           if [[ -d "web/app/themes/sage-test" ]]; then
             echo "Deleting existing sage-test..."

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - '/private/scripts/**'
+      - 'private/scripts/**'
 jobs:
   test:
     name: Sage Install Tests

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -139,3 +139,9 @@ jobs:
       - name: Delete multidev
         if: always()
         run: terminus multidev:delete --delete-branch --yes wpcm-sage-install-tests.$multidev_name
+      - name: Delete all tags
+        if: always()
+        run: |
+          cd ~/pantheon-local-copies/wpcm-sage-install-tests
+          git tag -d $(git tag -l)
+          git push origin --delete $(git tag -l)

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -37,7 +37,7 @@ jobs:
           esac
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          pr_num="${{ github.event.pull_request.number }}"
+          pr_num="${{ github.event.number }}"
 
           multidev_name="${os_short}-${php_short}-${pr_num}"
           echo "Generated multidev name: $multidev_name"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -97,10 +97,14 @@ jobs:
             echo "Deleting existing sage-test..."
             rm -rf web/app/themes/sage-test
           fi
+          # Temporarily gitignore web/apps/themes/sage-test.
+          echo "web/app/themes/sage-test" >> .gitignore
           terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
           echo "Checking out multidev..."
           git fetch --all
           git checkout $multidev_name
+          # Remove web/app/themes/sage-test from .gitignore.
+          sed -i '' '/web\/app\/themes\/sage-test/d' .gitignore
       - name: Copy latest repository changes
         run: |
           # Sync the files from checked-out repo to pantheon-local-copies, excluding the .git folder

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -29,9 +29,13 @@ jobs:
           sudo mv terminus /usr/local/bin/
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
-      - name: Run Sage Install Script
+      - name: Log into Terminus & Create Multidev
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
+          terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
+          terminus site:create-env --site=wpcm-sage-install-tests --to-env=${{ matrix.os }}-${{ github.event.pull_request.number }} --from-env=dev
+      - name: Run Sage Install Script
+        run: |
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then
             echo "❌ Sage Install Script Failed with exit code ${exit_code}"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -56,7 +56,8 @@ jobs:
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
           terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
-          terminus site:create-env --site=wpcm-sage-install-tests --to-env=$multidev_name --from-env=dev
+          terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
+        shell: bash
       - name: Run Sage Install Script
         run: |
           composer install-sage || exit_code=$?
@@ -68,3 +69,6 @@ jobs:
             exit 0;
           fi
         shell: bash
+      - name: Delete multidev
+        if: always()
+        run: terminus multidev:delete --delete-branch --yes wpcm-sage-install-tests.$multidev_name

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -141,4 +141,4 @@ jobs:
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
           git fetch --tags origin
           git tag -d pantheon_build_artifacts_$multidev_name
-          git push origin --delete pantheon_build_artifacts-$multidev_name
+          git push origin --delete pantheon_build_artifacts_$multidev_name

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -119,7 +119,7 @@ jobs:
           SAGENAME: sage-test
           SITENAME: wpcm-sage-install-tests
           CI: 1
-          SITEENV: $multidev_name
+          SITEENV: "$multidev_name"
           PHPVERSION: ${{ matrix.php-version }}
         run: |
           cd ~/pantheon-local-copies/$SITENAME

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -74,6 +74,12 @@ jobs:
             terminus --version
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
+      - name: Validate Pantheon Host Key
+        run: |
+          ssh-keyscan -t rsa drush.in >> ~/.ssh/known_hosts
+          echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config
+          echo "Host *.drush.in PubkeyAcceptedKeyTypes +ssh-rsa" >> ~/.ssh/config
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
       - name: Log into Terminus, Create Multidev and Clone Site
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -64,14 +64,12 @@ jobs:
           echo "multidev_name=$multidev_name" >> $GITHUB_ENV
       - name: Get latest Terminus release
         run: |
-          latest_version=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | jq -r .tag_name)
-          echo "Latest Terminus version: $latest_version"
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             echo "☕ Installing Terminus on macOS from Homebrew..."
             brew install pantheon-systems/external/terminus
           else
             echo "💻 Installing Terminus from phar on Linux..."
-            curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
+            curl -L "https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar" -o terminus
             chmod +x terminus
             sudo mv terminus /usr/local/bin/
           fi

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -3,10 +3,6 @@ on:
   push:
     paths:
       - '.github/workflows/sage-test.yml'
-  pull_request:
-    branches:
-      - main
-    paths:
       - 'private/scripts/**'
 jobs:
   test:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -31,7 +31,7 @@ jobs:
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Run Sage Install Script
         run: |
-          terminus auth:login --machine-token=${TERMINUS_TOKEN}
+          terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then
             echo "❌ Sage Install Script Failed with exit code ${exit_code}"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -76,7 +76,6 @@ jobs:
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Validate Pantheon Host Key
         run: |
-          ssh-keyscan -t rsa drush.in >> ~/.ssh/known_hosts
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config
           echo "Host *.drush.in PubkeyAcceptedKeyTypes +ssh-rsa" >> ~/.ssh/config
           echo "StrictHostKeyChecking no" >> ~/.ssh/config

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     name: Sage Install Tests
+    env:
+      TERM: xterm-256color
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -82,6 +82,17 @@ jobs:
           git checkout $multidev_name
           echo "Installing Composer dependencies..."
           composer install --no-progress --no-suggest --prefer-dist
+      - name: Copy latest repository changes
+        run: |
+          # Sync the files from checked-out repo to pantheon-local-copies, excluding the .git folder
+          rsync -av --exclude='.git/' ${{ github.workspace }}/ ~/pantheon-local-copies/wpcm-sage-install-tests/
+          # Navigate to Pantheon local copies directory
+          cd ~/pantheon-local-copies/wpcm-sage-install-tests/
+
+          # Add, commit and push
+          git add .
+          git commit -m "Sync latest changes to test environment"
+          git push origin $multidev_name
       - name: Run Sage Install Script
         run: |
           SAGENAME=sage-test

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -78,10 +78,11 @@ jobs:
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
           terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
-          terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
           echo "Cloning site..."
           terminus local:clone wpcm-sage-install-tests
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
+          terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
+          echo "Checking out multidev..."
           git fetch --all
           git checkout $multidev_name
           echo "Installing Composer dependencies..."

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php-version: [7.4, 8.0, 8.1, 8.2]
+        php-version: [8.0, 8.1, 8.2]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -7,7 +7,8 @@ on:
     paths:
       - '/private/scripts/**'
 jobs:
-  linux:
+  test:
+    name: Sage Theme Install Tests
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -54,11 +55,15 @@ jobs:
           echo "multidev_name=$multidev_name" >> $GITHUB_ENV
       - name: Get latest Terminus release
         run: |
-          latest_version=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | jq -r .tag_name)
-          echo "Terminus Latest version is $latest_version"
-          curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
-          chmod +x terminus
-          sudo mv terminus /usr/local/bin/
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            echo "☕ Installing Terminus on macOS from Homebrew..."
+            brew install pantheon-systems/external/terminus
+          else
+            echo "💻 Installing Terminus from phar on Linux..."
+            curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
+            chmod +x terminus
+            sudo mv terminus /usr/local/bin/
+          fi
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Log into Terminus & Create Multidev

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -58,7 +58,12 @@ jobs:
           echo "Terminus Latest version is $latest_version"
           curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
           chmod +x terminus
-          sudo mv terminus /usr/local/bin/
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            echo "Adding currnt directory to PATH for Windows..."
+            echo "./" >> $GITHUB_PATH
+          else
+            sudo mv terminus /usr/local/bin/
+          fi
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Log into Terminus & Create Multidev

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -98,7 +98,8 @@ jobs:
           rsync -av --exclude='.git/' ${{ github.workspace }}/ ~/pantheon-local-copies/wpcm-sage-install-tests/
           # Navigate to Pantheon local copies directory
           cd ~/pantheon-local-copies/wpcm-sage-install-tests/
-
+          git config --global user.email "bot@getpantheon.com"
+          git config --global user.name "Pantheon TestBot"
           # Add, commit and push
           git add .
           git commit -m "Sync latest changes to test environment"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -142,4 +142,5 @@ jobs:
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
           git fetch --tags origin
           git tag -d pantheon_build_artifacts_$multidev_name
-          git push origin --delete pantheon_build_artifacts_$multidev_name
+          # Allow this to fail.
+          git push origin --delete pantheon_build_artifacts_$multidev_name || true

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -20,6 +20,29 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+      - name: Generate multidev name
+        id: generate_name
+        run: |
+          os_short=""
+          case "${{ matrix.os }}" in
+            ubuntu-latest)
+              os_short="nix"
+              ;;
+            macos-latest)
+              os_short="mac"
+              ;;
+            windows-latest)
+              os_short="win"
+              ;;
+          esac
+
+          php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
+          pr_num="${{ github.event.pull_request.number }}"
+
+          multidev_name="${os_short}-${php_short}-${pr_num}"
+          echo "Generated multidev name: $multidev_name"
+          echo "multidev_name=$multidev_name" >> $GITHUB_ENV
+        shell: bash
       - name: Get latest Terminus release
         run: |
           latest_version=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | jq -r .tag_name)
@@ -33,7 +56,7 @@ jobs:
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
           terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
-          terminus site:create-env --site=wpcm-sage-install-tests --to-env=${{ matrix.os }}-${{ github.event.pull_request.number }} --from-env=dev
+          terminus site:create-env --site=wpcm-sage-install-tests --to-env=$multidev_name --from-env=dev
       - name: Run Sage Install Script
         run: |
           composer install-sage || exit_code=$?

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           SAGENAME=sage-test
           SITENAME=wpcm-sage-install-tests
+          cd ~/pantheon-local-copies/$SITENAME
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then
             echo "❌ Sage Install Script Failed with exit code ${exit_code}"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -126,14 +126,8 @@ jobs:
           export SITEENV=$multidev_name
           export PHPVERSION=${{ matrix.php-version }}
           cd ~/pantheon-local-copies/$SITENAME
-          composer install-sage || exit_code=$?
-          if [[ -n "${exit_code}" ]]; then
-            echo "❌ Sage Install Script Failed with exit code ${exit_code}"
-            exit $exit_code
-          else
-            echo "✅ Sage Install Script passed!"
-            exit 0;
-          fi
+          composer install-sage
+          echo "✅ Sage Install Script passed!"
       - name: Delete multidev
         if: always()
         run: terminus multidev:delete --delete-branch --yes wpcm-sage-install-tests.$multidev_name

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -1,0 +1,34 @@
+name: Sage Install Tests
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '/private/scripts/**'
+jobs:
+  linux:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        php-version: [7.4, 8.0, 8.1, 8.2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+      - name: Install Composer Dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist
+      - name: Run Sage Install Script
+        run: |
+          composer install-sage || exit_code=$?
+          if [[ -n "${exit_code}" ]]; then
+            echo "❌ Sage Install Script Failed with exit code ${exit_code}"
+            exit $exit_code
+          else
+            echo "✅ Sage Install Script passed!"
+            exit 0;
+          fi
+        shell: bash

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -119,9 +119,9 @@ jobs:
           SAGENAME: sage-test
           SITENAME: wpcm-sage-install-tests
           CI: 1
-          SITEENV: "$multidev_name"
           PHPVERSION: ${{ matrix.php-version }}
         run: |
+          export SITEENV=$multidev_name
           cd ~/pantheon-local-copies/$SITENAME
           composer install-sage
           echo "✅ Sage Install Script passed!"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -139,9 +139,9 @@ jobs:
       - name: Delete multidev
         if: always()
         run: terminus multidev:delete --delete-branch --yes wpcm-sage-install-tests.$multidev_name
-      - name: Delete all tags
+      - name: Delete the multidev build artifact
         if: always()
         run: |
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
-          git tag -d $(git tag -l)
-          git push origin --delete $(git tag -l)
+          git tag -d pantheon_build_artifacts-$multidev_name
+          git push origin --delete pantheon_build_artifacts-$multidev_name

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -120,6 +120,7 @@ jobs:
           SITENAME: wpcm-sage-install-tests
           CI: 1
           PHPVERSION: ${{ matrix.php-version }}
+          SITEENV: ${{ env.multidev_name }}
         run: |
           export SITEENV=$multidev_name
           cd ~/pantheon-local-copies/$SITENAME

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -17,12 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Get PR number
-        uses: actions/github-script@v4
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const pr = context.payload.number;
-            core.exportVariable('PR_NUMBER', pr);
+        id: pr
+        run: echo "::set-output name=pull_request_number::$(gh pr view --json number -q .number || echo "")"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -21,6 +21,7 @@ jobs:
         run: echo "::set-output name=pull_request_number::$(gh pr view --json number -q .number || echo "")"
         env:
           GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -57,8 +58,10 @@ jobs:
           curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
           chmod +x terminus
           sudo mv terminus /usr/local/bin/
+        shell: bash
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
+        shell: bash
       - name: Log into Terminus & Create Multidev
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
@@ -79,3 +82,4 @@ jobs:
       - name: Delete multidev
         if: always()
         run: terminus multidev:delete --delete-branch --yes wpcm-sage-install-tests.$multidev_name
+        shell: bash

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -37,7 +37,7 @@ jobs:
           esac
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          pr_num="${{ github.event.number }}"
+          pr_num=$(echo "${{ github.event.number }}")
 
           multidev_name="${os_short}-${php_short}-${pr_num}"
           echo "Generated multidev name: $multidev_name"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -28,9 +28,14 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Get PR number
         id: pr
-        run: echo "::set-output name=pull_request_number::$(gh pr view --json number -q .number || echo "")"
+        run: echo "pull_request_number=$(gh pr view --json number -q .number || echo '')" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ github.token }}
+      - name: Extract PR number
+        id: extract_pr
+        run: |
+          pr_num=$(grep "pull_request_number" $GITHUB_OUTPUT | cut -d '=' -f2)
+          echo "pr_num=$pr_num" >> $GITHUB_ENV
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,7 +57,6 @@ jobs:
           esac
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          pr_num=$(echo ${{ steps.pr.outputs.pull_request_number }})
           echo "PR number: $pr_num"
           echo "OS: $os_short"
           echo "PHP: $php_short"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -109,6 +109,7 @@ jobs:
           export SAGENAME=sage-test
           export SITENAME=wpcm-sage-install-tests
           export CI=1
+          export SITEENV=$multidev_name
           cd ~/pantheon-local-copies/$SITENAME
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -77,6 +77,8 @@ jobs:
           terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
       - name: Run Sage Install Script
         run: |
+          SAGENAME=sage-test
+          SITENAME=wpcm-sage-install-tests
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then
             echo "❌ Sage Install Script Failed with exit code ${exit_code}"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -1,9 +1,9 @@
 name: Sage Install Tests
 on:
+  push:
   pull_request:
     branches:
       - main
-      - '**'
     paths:
       - '/private/scripts/**'
 jobs:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -98,8 +98,6 @@ jobs:
           echo "Checking out multidev..."
           git fetch --all
           git checkout $multidev_name
-          echo "Installing Composer dependencies..."
-          composer install --no-progress --no-suggest --prefer-dist
       - name: Copy latest repository changes
         run: |
           # Sync the files from checked-out repo to pantheon-local-copies, excluding the .git folder
@@ -112,6 +110,10 @@ jobs:
           git add .
           git commit -m "Sync latest changes to test environment"
           git push origin $multidev_name
+      - name: Install Composer Dependencies
+        run: |
+          cd ~/pantheon-local-copies/wpcm-sage-install-tests
+          composer install
       - name: Run Sage Install Script
         run: |
           export SAGENAME=sage-test

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   linux:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -21,7 +24,6 @@ jobs:
         run: echo "::set-output name=pull_request_number::$(gh pr view --json number -q .number || echo "")"
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        shell: bash
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -50,7 +52,6 @@ jobs:
           multidev_name="${os_short}-${php_short}-${pr_num}"
           echo "Generated multidev name: $multidev_name"
           echo "multidev_name=$multidev_name" >> $GITHUB_ENV
-        shell: bash
       - name: Get latest Terminus release
         run: |
           latest_version=$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | jq -r .tag_name)
@@ -58,16 +59,13 @@ jobs:
           curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
           chmod +x terminus
           sudo mv terminus /usr/local/bin/
-        shell: bash
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
-        shell: bash
       - name: Log into Terminus & Create Multidev
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
           terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
           terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
-        shell: bash
       - name: Run Sage Install Script
         run: |
           composer install-sage || exit_code=$?
@@ -78,8 +76,6 @@ jobs:
             echo "✅ Sage Install Script passed!"
             exit 0;
           fi
-        shell: bash
       - name: Delete multidev
         if: always()
         run: terminus multidev:delete --delete-branch --yes wpcm-sage-install-tests.$multidev_name
-        shell: bash

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -31,6 +31,7 @@ jobs:
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Run Sage Install Script
         run: |
+          terminus auth:login --machine-token=${TERMINUS_TOKEN}
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then
             echo "❌ Sage Install Script Failed with exit code ${exit_code}"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -63,7 +63,9 @@ jobs:
             curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
             chmod +x terminus
             sudo mv terminus /usr/local/bin/
-          fi
+            fi
+            # Test that terminus works...
+            terminus --version
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Log into Terminus & Create Multidev

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install SSH keys
-        uses: webfactory/ssh-agent@v0.5.0
+        uses: webfactory/ssh-agent@v0.8.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Get PR number

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -8,7 +8,7 @@ on:
       - '/private/scripts/**'
 jobs:
   test:
-    name: Sage Theme Install Tests
+    name: Sage Install Tests
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -88,6 +88,12 @@ jobs:
           echo "Cloning site..."
           terminus local:clone wpcm-sage-install-tests
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
+          ls -la ~/pantheon-local-copies/wpcm-sage-install-tests
+          # If sage-test exists, delete it.
+          if [[ -d "web/app/themes/sage-test" ]]; then
+            echo "Deleting existing sage-test..."
+            rm -rf web/app/themes/sage-test
+          fi
           terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
           echo "Checking out multidev..."
           git fetch --all

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -44,7 +44,7 @@ jobs:
           esac
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          pr_num=$PR_NUMBER
+          pr_num=$(echo "$PR_NUMBER")
 
           multidev_name="${os_short}-${php_short}-${pr_num}"
           echo "Generated multidev name: $multidev_name"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -16,6 +16,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Get PR number
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const core = require('@actions/core');
+            const pr = context.payload.number;
+            core.exportVariable('PR_NUMBER', pr);
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -37,7 +45,7 @@ jobs:
           esac
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          pr_num=$(echo "${{ github.event.number }}")
+          pr_num=$PR_NUMBER
 
           multidev_name="${os_short}-${php_short}-${pr_num}"
           echo "Generated multidev name: $multidev_name"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -140,5 +140,5 @@ jobs:
         run: |
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
           git fetch --tags origin
-          git tag -d pantheon_build_artifacts-$multidev_name
+          git tag -d pantheon_build_artifacts_$multidev_name
           git push origin --delete pantheon_build_artifacts-$multidev_name

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -139,5 +139,6 @@ jobs:
         if: always()
         run: |
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
+          git fetch --tags origin
           git tag -d pantheon_build_artifacts-$multidev_name
           git push origin --delete pantheon_build_artifacts-$multidev_name

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -74,8 +74,6 @@ jobs:
             fi
             # Test that terminus works...
             terminus --version
-      - name: Install Composer Dependencies
-        run: composer install --no-progress --no-suggest --prefer-dist
       - name: Validate Pantheon Host Key
         run: |
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -70,11 +70,18 @@ jobs:
             terminus --version
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
-      - name: Log into Terminus & Create Multidev
+      - name: Log into Terminus, Create Multidev and Clone Site
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
           terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
           terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
+          echo "Cloning site..."
+          terminus local:clone wpcm-sage-install-tests
+          cd ~/pantheon-local-copies/wpcm-sage-install-tests
+          git fetch --all
+          git checkout $multidev_name
+          echo "Installing Composer dependencies..."
+          composer install --no-progress --no-suggest --prefer-dist
       - name: Run Sage Install Script
         run: |
           SAGENAME=sage-test

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Install SSH keys
+        uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Get PR number
         id: pr
         run: echo "::set-output name=pull_request_number::$(gh pr view --json number -q .number || echo "")"

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -88,7 +88,10 @@ jobs:
           echo "Cloning site..."
           terminus local:clone wpcm-sage-install-tests
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
-          git diff
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "❌ Local clone is dirty. Exiting..."
+            exit 1
+          fi
           # If sage-test exists, delete it.
           if [[ -d "web/app/themes/sage-test" ]]; then
             echo "Deleting existing sage-test..."

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -97,14 +97,10 @@ jobs:
             echo "Deleting existing sage-test..."
             rm -rf web/app/themes/sage-test
           fi
-          # Temporarily gitignore web/apps/themes/sage-test.
-          echo "web/app/themes/sage-test" >> .gitignore
           terminus multidev:create wpcm-sage-install-tests.dev $multidev_name
           echo "Checking out multidev..."
           git fetch --all
           git checkout $multidev_name
-          # Remove web/app/themes/sage-test from .gitignore.
-          sed -i '' '/web\/app\/themes\/sage-test/d' .gitignore
       - name: Copy latest repository changes
         run: |
           # Sync the files from checked-out repo to pantheon-local-copies, excluding the .git folder

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -28,7 +28,7 @@ jobs:
         id: pr
         run: |
           pr_num=$(gh pr view --json number -q .number || echo "")
-          echo "pr_num=$pr_num" >> $GITHUB_ENV
+          echo "PR_NUM=$pr_num" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Setup PHP
@@ -52,10 +52,10 @@ jobs:
           esac
 
           php_short=$(echo "${{ matrix.php-version }}" | tr -d '.')
-          echo "PR number: $pr_num"
+          echo "PR number: $PR_NUM"
           echo "OS: $os_short"
           echo "PHP: $php_short"
-          multidev_name="${os_short}-${php_short}-${pr_num}"
+          multidev_name="${os_short}-${php_short}-${PR_NUM}"
           echo "Generated multidev name: $multidev_name"
           echo "multidev_name=$multidev_name" >> $GITHUB_ENV
       - name: Get latest Terminus release

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -74,9 +74,9 @@ jobs:
             curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
             chmod +x terminus
             sudo mv terminus /usr/local/bin/
-            fi
-            # Test that terminus works...
-            terminus --version
+          fi
+          # Test that terminus works...
+          terminus --version
       - name: Validate Pantheon Host Key
         run: |
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - '**'
     paths:
       - '/private/scripts/**'
 jobs:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -106,8 +106,9 @@ jobs:
           git push origin $multidev_name
       - name: Run Sage Install Script
         run: |
-          SAGENAME=sage-test
-          SITENAME=wpcm-sage-install-tests
+          export SAGENAME=sage-test
+          export SITENAME=wpcm-sage-install-tests
+          export CI=1
           cd ~/pantheon-local-copies/$SITENAME
           composer install-sage || exit_code=$?
           if [[ -n "${exit_code}" ]]; then

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -79,10 +79,12 @@ jobs:
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config
           echo "Host *.drush.in PubkeyAcceptedKeyTypes +ssh-rsa" >> ~/.ssh/config
           echo "StrictHostKeyChecking no" >> ~/.ssh/config
-      - name: Log into Terminus, Create Multidev and Clone Site
+      - name: Log into Terminus and Check for updates
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
           terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
+      - name: Clone site and create multidev
+        run: |
           echo "Cloning site..."
           terminus local:clone wpcm-sage-install-tests
           cd ~/pantheon-local-copies/wpcm-sage-install-tests

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -14,7 +14,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         php-version: [8.0, 8.1, 8.2]
     steps:
       - name: Checkout
@@ -58,12 +58,7 @@ jobs:
           echo "Terminus Latest version is $latest_version"
           curl -L "https://github.com/pantheon-systems/terminus/releases/download/$latest_version/terminus.phar" -o terminus
           chmod +x terminus
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            echo "Adding currnt directory to PATH for Windows..."
-            echo "./" >> $GITHUB_PATH
-          else
-            sudo mv terminus /usr/local/bin/
-          fi
+          sudo mv terminus /usr/local/bin/
       - name: Install Composer Dependencies
         run: composer install --no-progress --no-suggest --prefer-dist
       - name: Log into Terminus & Create Multidev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2023-09-25
+* Updates to the [Sage install script](docs/Installing-Sage.md) to support running the script without prompting for input. Also adds automated test runs of the script on `ubuntu-latest` and `macos-latest` environments. ([#113](https://github.com/pantheon-systems/wordpress-composer-managed/pull/113))
+
 ### 2023-06-27
 * Fixed a bug that failed to prevent a `composer.lock` file from being committed to the repository. ([#103](https://github.com/pantheon-systems/wordpress-composer-managed/pull/103))
 * Removed the `upstream-require` script ([#105](https://github.com/pantheon-systems/wordpress-composer-managed/pull/105)). This is now available as a standalone Composer plugin: [`pantheon-systems/upstream-management`](https://packagist.org/packages/pantheon-systems/upstream-management)

--- a/docs/Installing-Sage.md
+++ b/docs/Installing-Sage.md
@@ -27,6 +27,41 @@ If you have all the above requirements, including a copy of the site locally, `c
 composer install-sage
 ```
 
+### Running the Script in Headless Mode
+
+The script can also be run with no user interaction at all. Instead of answering the prompts in the script itself, you can pass information via environment variables before running the script. The following environment variables are available:
+
+* **`SITENAME`** - The name of the site on Pantheon. This is the name that you would use to run Terminus commands like `terminus site:info` or `terminus wp`. This is not required if the script is being run from inside a site repo.
+* **`SFTPUSER`** - The SFTP username for the site. This is not required if the script is being run from inside a site repo. This is the SFTP username that you can get from the Pantheon dashboard.
+* **`SFTPHOST`** - The SFTP hostname for the site. This is not required if the script is being run from inside a site repo. This is the SFTP hostname that you can get from the Pantheon dashboard.
+* **`SAGENAME`** - The name of the theme that you want to create. This is _required_.
+* **`PHPVERSION`** - The PHP version that you want to use. This is optional and defaults to `8.0`. `8.3` is a valid option but will be updated to 8.2 until PHP 8.3 is available on Pantheon.
+* **`SITEENV`** - The Pantheon environment that you want to use. This is optional and defaults to `dev`. This is the environment that you want to install the theme on. This can be `dev` or any valid multidev.
+* **`CI`** - Whether the script is being run from a Continuous Integration (CI) environment. When this exists, additional time is given to allow simultaneous workflows to run and the script will not attempt to open the site in a browser. This is optional and defaults to `0` (`false`). If you want to enable CI-mode, set this to `1`.
+
+### Using environment variables
+
+You can use any environment variables you want by simply `export`ing them in your shell or bash script before running the script. For example:
+
+```bash
+export SAGENAME="sage-theme"
+export PHPVERSION="8.2"
+export SITEENV="sage-1"
+export SITENAME="my-site"
+terminus multidev:create "$SITENAME".dev "$SITEENV"
+git fetch --all
+git checkout "$SITEENV"
+composer install-sage
+``` 
+
+The above code will:
+
+* Set the Sage theme name to `sage-theme`
+* Set the PHP version to `8.2` in `pantheon.yml`
+* Create a multidev environment named `sage-1`
+* Check out the `sage-1` branch
+* Run the Sage installation script on the `sage-1` multidev environment
+
 ## How it Works
 The script does a lot of things and each step builds onto the last. You can look at the script in [`private/scripts/sage-theme-install.sh`](../private/scripts/sage-theme-install.sh) if you're interested in the precise commands that are being run. This overview will walk through each step.
 

--- a/docs/Installing-Sage.md
+++ b/docs/Installing-Sage.md
@@ -37,7 +37,7 @@ The script can also be run with no user interaction at all. Instead of answering
 * **`SAGENAME`** - The name of the theme that you want to create. This is _required_.
 * **`PHPVERSION`** - The PHP version that you want to use. This is optional and defaults to `8.0`. `8.3` is a valid option but will be updated to 8.2 until PHP 8.3 is available on Pantheon.
 * **`SITEENV`** - The Pantheon environment that you want to use. This is optional and defaults to `dev`. This is the environment that you want to install the theme on. This can be `dev` or any valid multidev.
-* **`CI`** - Whether the script is being run from a Continuous Integration (CI) environment. When this exists, additional time is given to allow simultaneous workflows to run and the script will not attempt to open the site in a browser. This is optional and defaults to `0` (`false`). If you want to enable CI-mode, set this to `1`.
+* **`CI`** - Whether the script is being run from a Continuous Integration (CI) environment. When this exists, additional time is given to allow simultaneous workflows to run and the script will not attempt to open the site in a browser. This is optional and defaults to `0` (`false`). If you want to enable CI-mode, set this to `1`. Setting the `CI` variable to `1` will also remove the confirmation prompts and prevent the script from restarting if no input is entered. _Only use this if you are sure you have the correct information_ as the script will run autonomously with whatever data it is able to fetch from Terminus based on the current site repository.
 
 ### Using environment variables
 

--- a/docs/Installing-Sage.md
+++ b/docs/Installing-Sage.md
@@ -63,7 +63,7 @@ The above code will:
 * Run the Sage installation script on the `sage-1` multidev environment
 
 ## How it Works
-The script does a lot of things and each step builds onto the last. You can look at the script in [`private/scripts/sage-theme-install.sh`](../private/scripts/sage-theme-install.sh) if you're interested in the precise commands that are being run. This overview will walk through each step.
+The script does a lot of things and each step builds onto the last. You can look at the script in [`private/scripts/helpers.sh`](../private/scripts/helpers.sh) if you're interested in the precise commands that are being run. This overview will walk through each step.
 
 ### Check Login
 The first thing the script will do is check to see if you are logged into Terminus with a `terminus whoami` command. If you are not logged in, the script will end and you will be prompted to log in first.

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -169,7 +169,7 @@ function get_info() {
   fi
 
   if [ -z "$sitename" ] || [ -z "$sagename" ] || [ -z "$sftpuser" ] || [ -z "$sftphost" ]; then
-    echo "${red}Missing information!${normal} Make sure you've everything for all the prompts."
+    echo "${red}Missing information!${normal} Make sure you input everything for all the prompts."
     get_info
   fi
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -471,18 +471,18 @@ function clean_up() {
     exit 1;
   fi
 
-  if [ "$is_ci" -ne 1 ]; then
-    # Switch back to SFTP so files can be written.
-    terminus connection:set "$sitename"."$siteenv" sftp
+  # Switch back to SFTP so files can be written.
+  terminus connection:set "$sitename"."$siteenv" sftp
 
+  if [ "$is_ci" -ne 1 ]; then
     # Open the site. This should generate requisite files on page load.
     echo "${yellow}Opening the ${siteenv}-${sitename}.pantheonsite.io to generate requisite files.${normal}"
     open https://"$siteenv"-"$sitename".pantheonsite.io
-
-    # Commit any additions found in SFTP mode.
-    echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
-    terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
   fi
+
+  # Commit any additions found in SFTP mode.
+  echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
+  terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
 
   # Switch back to Git.
   terminus connection:set "$sitename"."$siteenv" git

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -446,7 +446,7 @@ function update_composer() {
 # Finish up the Sage install process.
 function clean_up() {
   # List the app/ehemes directory.
-  echo "${yellow}Listing the themes directory.${normal}"
+  echo "${yellow}Checking the themes directory for ${sagename}.${normal}"
   # If the previous output did not include $sagename, bail.
   if [[ ! "$(ls -la web/app/themes)" == *"$sagename"* ]]; then
     echo "${red}Theme not found. Exiting here.${normal}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -396,7 +396,7 @@ function update_composer() {
   git add composer.json
   git commit -m "[Sage Install] Add post-install-cmd hook to also run install on ${sagename}"
 
-  if ! git push origin master; then+
+  if ! git push origin master; then
     echo "${red}Push failed. Stopping here.${normal}"
     echo "Next steps are to push the changes to the repo and then set the connection mode back to Git."
     exit 1;

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -388,7 +388,13 @@ function update_composer() {
 
   # Wait for the build to finish.
   echo "${yellow}Waiting for the deploy to finish.${normal}"
-  if ! terminus workflow:wait --max=90 "$sitename".dev; then
+  if [ "$is_ci" -eq 1 ]; then
+    echo "${yellow}CI detected. We'll need to wait longer.${normal}"
+    waittime=600
+  else
+    waittime=90
+  fi
+  if ! terminus workflow:wait --max="$waittime" "$sitename".dev; then
     echo "${red}terminus workflow:wait command not found. Stopping here.${normal}"
     echo "You will need to install the terminus-build-tools-plugin."
     echo "terminus self:plugin:install terminus-build-tools-plugin"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -20,7 +20,7 @@ sftpuser="${SFTPUSER:-}"
 sftphost="${SFTPHOST:-}"
 sagename="${SAGENAME:-}"
 phpversion="${PHPVERSION:-8.0}"
-is_ci="${CI:-}"
+is_ci="${CI:-0}"
 siteenv="${SITEENV:-dev}"
 if [ "$siteenv" == "dev" ]; then
   branch="master"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -389,8 +389,6 @@ function update_composer() {
   echo "${yellow}Adding a post-install hook to composer.json.${normal}"
   jq -r '.scripts += { "post-install-cmd": [ "@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=%sagedir%" ] }' composer.json > composer.new.json
 
-  pwd
-
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OS
     if ! sed -i '' "s,%sagedir%,$sagedir," composer.new.json; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -267,6 +267,7 @@ function update_php() {
       sed -i '' "s/7.4/${phpversion}/" pantheon.yml
     else
       # Add full PHP version declaration to pantheon.yml.
+      echo "" >> pantheon.yml
       echo "php_version: ${phpversion}" >> pantheon.yml
     fi
     git status

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -244,7 +244,7 @@ function update_php() {
     fi
   fi
   echo ""
-  echo "${yellow}Updating PHP version to 8.0.${normal}"
+  echo "${yellow}Updating PHP version to ${phpversion}.${normal}"
 
   # Check for pantheon.yml file.
   if [ ! -f "pantheon.yml" ]; then
@@ -262,12 +262,12 @@ function update_php() {
     # Test for PHP version declartion already in pantheon.yml.
     if [ ! "$phpDeclaredInFile" -eq 0 ]; then
       # Update version to 8.x.
-      sed -i '' "s/7.4/8.0/" pantheon.yml
+      sed -i '' "s/7.4/${phpversion}/" pantheon.yml
     else
       # Add full PHP version declaration to pantheon.yml.
-      echo "php_version: 8.0" >> pantheon.yml
+      echo "php_version: ${phpversion}" >> pantheon.yml
     fi
-    git commit -am "[Sage Install] Update PHP version to 8.0"
+    git commit -am "[Sage Install] Update PHP version to ${phpversion}"
     git push origin "$branch"
   else
     echo "${green}PHP version is already 8.x.${normal}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -254,7 +254,7 @@ function update_php() {
       echo "php_version: 8.0" >> pantheon.yml
     fi
     git commit -am "[Sage Install] Update PHP version to 8.0"
-    git push origin $branch
+    git push origin "$branch"
   else
     echo "${green}PHP version is already 8.x.${normal}"
   fi
@@ -291,7 +291,7 @@ function install_sage_theme() {
   # Commit the theme
   git add "$sagedir"
   git commit -m "[Sage Install] Add the Sage theme ${sagename}."
-  git push origin $branch
+  git push origin "$branch"
   echo "${green}Sage installed!${normal}"
 }
 
@@ -325,7 +325,7 @@ EOF
   ln -sfn uploads/cache .
   git add .
   git commit -m "[Sage Install] Add a symlink for /files/cache to /uploads/cache"
-  git push origin $branch
+  git push origin "$branch"
   cd ../..
 }
 
@@ -366,7 +366,7 @@ function update_composer() {
     echo "${yellow}Updating composer.lock.${normal}"
     git add composer.lock
     git commit -m "[Sage Install] Update composer.lock"
-    git push origin $branch
+    git push origin "$branch"
   fi
 
   echo "${yellow}Attempting to add a post-install hook to composer.json.${normal}"
@@ -401,7 +401,7 @@ function update_composer() {
   git add composer.json
   git commit -m "[Sage Install] Add post-install-cmd hook to also run install on ${sagename}"
 
-  if ! git push origin $branch; then
+  if ! git push origin "$branch"; then
     echo "${red}Push failed. Stopping here.${normal}"
     echo "Next steps are to push the changes to the repo and then set the connection mode back to Git."
     exit 1;

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -428,6 +428,14 @@ function update_composer() {
 
 # Finish up the Sage install process.
 function clean_up() {
+  # List the app/ehemes directory.
+  echo "${yellow}Listing the themes directory.${normal}"
+  # If the previous output did not include $sagename, bail.
+  if [[ ! "$(ls -la web/app/themes)" == *"$sagename"* ]]; then
+    echo "${red}Theme not found. Exiting here.${normal}"
+    exit 1;
+  fi
+
   # If the site is multisite, we'll need to enable the theme so we can activate it.
   terminus wp -- "$sitename"."$siteenv" theme enable "$sagename"
   # List the themes.

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -293,7 +293,7 @@ function install_sage_theme() {
 # Create the symlink to the cache directory.
 function add_symlink() {
   # Switch to SFTP mode
-  terminus connection:set "$sitename".dev sftp
+  terminus connection:set "$sitename"."$siteenv" sftp
 
   if [ ! -d "web/app/uploads" ]; then
     echo "${yellow}Creating the uploads directory.${normal}"
@@ -312,7 +312,7 @@ function add_symlink() {
 EOF
 
     # Switch back to Git mode.
-    terminus connection:set "$sitename".dev git
+    terminus connection:set "$sitename"."$siteenv" git
 
   # Create the symlink to /files/cache.
   cd web/app || return
@@ -395,7 +395,7 @@ function update_composer() {
   else
     waittime=90
   fi
-  if ! terminus workflow:wait --max="$waittime" "$sitename".dev; then
+  if ! terminus workflow:wait --max="$waittime" "$sitename"."$siteenv"; then
     echo "${red}terminus workflow:wait command not found. Stopping here.${normal}"
     echo "You will need to install the terminus-build-tools-plugin."
     echo "terminus self:plugin:install terminus-build-tools-plugin"
@@ -405,20 +405,20 @@ function update_composer() {
   # Check for long-running workflows.
   if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" == *"running"* ]]; then
     echo "${yellow}Workflow still running, waiting another 30 seconds.${normal}"
-    terminus workflow:wait --max=30 "$sitename".dev
+    terminus workflow:wait --max=30 "$sitename"."$siteenv"
   fi
 }
 
 # Finish up the Sage install process.
 function clean_up() {
   # If the site is multisite, we'll need to enable the theme so we can activate it.
-  terminus wp -- "$sitename".dev theme enable "$sagename"
+  terminus wp -- "$sitename"."$siteenv" theme enable "$sagename"
   # List the themes.
-  terminus wp -- "$sitename".dev theme list
+  terminus wp -- "$sitename"."$siteenv" theme list
 
   # Activate the new theme
   echo "${yellow}Activating the ${sagename} theme.${normal}"
-  if ! terminus wp -- "$sitename".dev theme activate "$sagename"; then
+  if ! terminus wp -- "$sitename"."$siteenv" theme activate "$sagename"; then
     echo "${red}Theme activation failed. Exiting here.${normal}"
     echo "Check the theme list above. If the theme you created is not listed, it's possible that the deploy has not completed. You can try again in a few minutes using the following command:"
     echo "terminus wp -- $sitename.dev theme activate $sagename"
@@ -427,7 +427,7 @@ function clean_up() {
   fi
 
   # Switch back to SFTP so files can be written.
-  terminus connection:set "$sitename".dev sftp
+  terminus connection:set "$sitename"."$siteenv" sftp
 
   # Open the site. This should generate requisite files on page load.
   echo "${yellow}Opening the dev-${sitename}.pantheonsite.io to generate requisite files.${normal}"
@@ -435,10 +435,10 @@ function clean_up() {
 
   # Commit any additions found in SFTP mode.
   echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
-  terminus env:commit "$sitename".dev --message="[Sage Install] Add any leftover files found in SFTP mode."
+  terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
 
   # Switch back to Git.
-  terminus connection:set "$sitename".dev git
+  terminus connection:set "$sitename"."$siteenv" git
   git pull --ff --commit
 }
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -460,13 +460,15 @@ function clean_up() {
   # Switch back to SFTP so files can be written.
   terminus connection:set "$sitename"."$siteenv" sftp
 
-  # Open the site. This should generate requisite files on page load.
-  echo "${yellow}Opening the dev-${sitename}.pantheonsite.io to generate requisite files.${normal}"
-  open https://dev-"$sitename".pantheonsite.io
+  if [ "$is_ci" -ne 1 ]; then
+    # Open the site. This should generate requisite files on page load.
+    echo "${yellow}Opening the dev-${sitename}.pantheonsite.io to generate requisite files.${normal}"
+    open https://dev-"$sitename".pantheonsite.io
 
-  # Commit any additions found in SFTP mode.
-  echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
-  terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
+    # Commit any additions found in SFTP mode.
+    echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
+    terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
+  fi
 
   # Switch back to Git.
   terminus connection:set "$sitename"."$siteenv" git

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -14,18 +14,19 @@ yellow=$(tput setaf 3)
 #magenta=$(tput setaf 5)
 #cyan=$(tput setaf 6)
 
-  # Use environment variables if set, otherwise prompt for input
-  sitename="${SITENAME:-}"
-  sftpuser="${SFTPUSER:-}"
-  sftphost="${SFTPHOST:-}"
-  sagename="${SAGENAME:-}"
-  is_ci="${CI:-}"
-  siteenv="${SITEENV:-dev}"
-  if [ "$siteenv" == "dev" ]; then
-    branch="master"
-  else
-    branch="$siteenv"
-  fi
+# Use environment variables if set, otherwise prompt for input
+sitename="${SITENAME:-}"
+sftpuser="${SFTPUSER:-}"
+sftphost="${SFTPHOST:-}"
+sagename="${SAGENAME:-}"
+phpversion="${PHPVERSION:-8.0}"
+is_ci="${CI:-}"
+siteenv="${SITEENV:-dev}"
+if [ "$siteenv" == "dev" ]; then
+  branch="master"
+else
+  branch="$siteenv"
+fi
 
 # Main function that runs the script.
 function main() {
@@ -229,6 +230,19 @@ get_field() {
 
 # Update to PHP 8.0
 function update_php() {
+  if [ "$phpversion" != "8.0" ]; then
+    echo "${yellow}You've specified PHP version ${phpversion}. The default is 8.0, but we'll use the version you asked for.${normal}"
+    if [ "$phpversion" == "8.3" ];
+    then
+      echo "${yellow}PHP 8.3 is not yet supported. Using 8.2 instead.${normal}"
+      phpversion="8.2"
+    fi
+    # Check if $phpversion is < 8.0.
+    if [ "$(echo "$phpversion < 8.0" | bc)" -eq 1 ]; then
+      echo "${red}PHP version must be 8.0 or greater. Exiting here.${normal}"
+      exit 1;
+    fi
+  fi
   echo ""
   echo "${yellow}Updating PHP version to 8.0.${normal}"
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -230,6 +230,9 @@ get_field() {
 
 # Update to PHP 8.0
 function update_php() {
+  if [ "$phpversion" == "8" ]; then
+    phpversion="8.0"
+  fi
   if [ "$phpversion" != "8.0" ]; then
     echo "${yellow}You've specified PHP version ${phpversion}. The default is 8.0, but we'll use the version you asked for.${normal}"
     if [ "$phpversion" == "8.3" ];

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -418,7 +418,7 @@ function update_composer() {
   fi
 
   # Check for long-running workflows.
-  if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" == *"running"* ]]; then
+  if [[ "$(terminus workflow:wait --max=1 "${sitename}"."$siteenv")" == *"running"* ]]; then
     waittime=$(( waittime / 3 ))
     echo "${yellow}Workflow still running, waiting another ${waittime} seconds.${normal}"
     terminus workflow:wait --max="$waittime" "$sitename"."$siteenv"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -372,6 +372,9 @@ function update_composer() {
   # Add a post-install hook to the composer.json.
   echo "${yellow}Adding a post-install hook to composer.json.${normal}"
   jq -r '.scripts += { "post-install-cmd": [ "@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=%sagedir%" ] }' composer.json > composer.new.json
+
+  pwd
+
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OS
     sed -i '' "s,%sagedir%,$sagedir," composer.new.json

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -21,6 +21,11 @@ yellow=$(tput setaf 3)
   sagename="${SAGENAME:-}"
   is_ci="${CI:-}"
   siteenv="${SITEENV:-dev}"
+  if [ "$siteenv" == "dev" ]; then
+    branch="master"
+  else
+    branch="$siteenv"
+  fi
 
 # Main function that runs the script.
 function main() {
@@ -249,7 +254,7 @@ function update_php() {
       echo "php_version: 8.0" >> pantheon.yml
     fi
     git commit -am "[Sage Install] Update PHP version to 8.0"
-    git push origin master
+    git push origin $branch
   else
     echo "${green}PHP version is already 8.x.${normal}"
   fi
@@ -286,7 +291,7 @@ function install_sage_theme() {
   # Commit the theme
   git add "$sagedir"
   git commit -m "[Sage Install] Add the Sage theme ${sagename}."
-  git push origin master
+  git push origin $branch
   echo "${green}Sage installed!${normal}"
 }
 
@@ -320,7 +325,7 @@ EOF
   ln -sfn uploads/cache .
   git add .
   git commit -m "[Sage Install] Add a symlink for /files/cache to /uploads/cache"
-  git push origin master
+  git push origin $branch
   cd ../..
 }
 
@@ -361,7 +366,7 @@ function update_composer() {
     echo "${yellow}Updating composer.lock.${normal}"
     git add composer.lock
     git commit -m "[Sage Install] Update composer.lock"
-    git push origin master
+    git push origin $branch
   fi
 
   echo "${yellow}Attempting to add a post-install hook to composer.json.${normal}"
@@ -396,7 +401,7 @@ function update_composer() {
   git add composer.json
   git commit -m "[Sage Install] Add post-install-cmd hook to also run install on ${sagename}"
 
-  if ! git push origin master; then
+  if ! git push origin $branch; then
     echo "${red}Push failed. Stopping here.${normal}"
     echo "Next steps are to push the changes to the repo and then set the connection mode back to Git."
     exit 1;

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -270,7 +270,7 @@ function update_php() {
       echo "" >> pantheon.yml
       echo "php_version: ${phpversion}" >> pantheon.yml
     fi
-    git status
+    git diff HEAD~1 HEAD -- pantheon.yml
     git commit -am "[Sage Install] Update PHP version to ${phpversion}"
     git push origin "$branch"
   else

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -434,6 +434,7 @@ function update_composer() {
   fi
 
   # Check for long-running workflows.
+  echo "${yellow}Checking for long-running workflows.${normal}"
   if [[ "$(terminus workflow:wait --max=1 "${sitename}"."$siteenv")" == *"running"* ]]; then
     waittime=$(( waittime / 3 ))
     echo "${yellow}Workflow still running, waiting another ${waittime} seconds.${normal}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -291,7 +291,6 @@ function install_sage_theme() {
   # Commit the theme
   git add "$sagedir"
   git commit -m "[Sage Install] Add the Sage theme ${sagename}."
-  git push origin "$branch"
   echo "${green}Sage installed!${normal}"
 }
 
@@ -325,7 +324,6 @@ EOF
   ln -sfn uploads/cache .
   git add .
   git commit -m "[Sage Install] Add a symlink for /files/cache to /uploads/cache"
-  git push origin "$branch"
   cd ../..
 }
 
@@ -366,7 +364,6 @@ function update_composer() {
     echo "${yellow}Updating composer.lock.${normal}"
     git add composer.lock
     git commit -m "[Sage Install] Update composer.lock"
-    git push origin "$branch"
   fi
 
   echo "${yellow}Attempting to add a post-install hook to composer.json.${normal}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -14,6 +14,14 @@ yellow=$(tput setaf 3)
 #magenta=$(tput setaf 5)
 #cyan=$(tput setaf 6)
 
+  # Use environment variables if set, otherwise prompt for input
+  sitename="${SITENAME:-}"
+  sftpuser="${SFTPUSER:-}"
+  sftphost="${SFTPHOST:-}"
+  sagename="${SAGENAME:-}"
+  is_ci="${CI:-}"
+  siteenv="${SITEENV:-dev}"
+
 # Main function that runs the script.
 function main() {
   help_msg="Usage: bash ./private/scripts/helpers.sh <command>
@@ -45,13 +53,6 @@ function main() {
 
 # Get the site name, theme name, and SFTP credentials from the user.
 function get_info() {
-  # Use environment variables if set, otherwise prompt for input
-  sitename="${SITENAME:-}"
-  sftpuser="${SFTPUSER:-}"
-  sftphost="${SFTPHOST:-}"
-  sagename="${SAGENAME:-}"
-  is_ci="${CI:-}"
-
   # If is_restarted is unset, set it to 0.
   if [ -z "$is_restarted" ]; then
     is_restarted=0

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -380,6 +380,7 @@ function update_composer() {
     if ! sed -i '' "s,%sagedir%,$sagedir," composer.new.json; then
       echo "${red}Failed to add post-install hook to composer.json. Exiting here.${normal}"
       exit 1;
+    fi
   else
     # Linux
     if ! sed -i "s,%sagedir%,$sagedir," composer.new.json; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -476,8 +476,8 @@ function clean_up() {
 
   if [ "$is_ci" -ne 1 ]; then
     # Open the site. This should generate requisite files on page load.
-    echo "${yellow}Opening the dev-${sitename}.pantheonsite.io to generate requisite files.${normal}"
-    open https://dev-"$sitename".pantheonsite.io
+    echo "${yellow}Opening the ${siteenv}-${sitename}.pantheonsite.io to generate requisite files.${normal}"
+    open https://"$siteenv"-"$sitename".pantheonsite.io
 
     # Commit any additions found in SFTP mode.
     echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -448,7 +448,7 @@ function update_composer() {
 
 # Finish up the Sage install process.
 function clean_up() {
-  # List the app/ehemes directory.
+  # List the app/themes directory.
   echo "${yellow}Checking the themes directory for ${sagename}.${normal}"
   # If the previous output did not include $sagename, bail.
   if [[ ! "$(ls -la web/app/themes)" == *"$sagename"* ]]; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -437,7 +437,7 @@ function install_sage() {
   check_login
 
   themedir="web/app/themes"
-  siteinfo=$(terminus site:info $sitename)
+  siteinfo=$(terminus site:info "$sitename")
   id=$(get_field "ID" "$siteinfo")
   name=$(get_field "Name" "$siteinfo")
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -325,8 +325,8 @@ EOF
 }
 
 # Check if jq is installed. If it's not, try a couple ways of installing it.
-# Check if jq is installed. If it's not, try a couple ways of installing it.
 function check_jq() {
+  echo "${yellow}Checking if jq is installed.${normal}"
   # Check if jq is already installed.
   if command -v jq &> /dev/null; then
       return # jq is already installed

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -379,8 +379,7 @@ function update_composer() {
     # Linux
     sed -i "s,%sagedir%,$sagedir," composer.new.json
   fi
-  sed -i '' "s,%sagedir%,$sagedir," composer.new.json
-  if [ $? -ne 0 ]; then
+  if ! sed -i '' "s,%sagedir%,$sagedir," composer.new.json; then
     echo "${red}Failed to add post-install hook to composer.json. Exiting here.${normal}"
     exit 1;
   fi

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -45,6 +45,12 @@ function main() {
 
 # Get the site name, theme name, and SFTP credentials from the user.
 function get_info() {
+  # Use environment variables if set, otherwise prompt for input
+  sitename="${SITENAME:-}"
+  sftpuser="${SFTPUSER:-}"
+  sftphost="${SFTPHOST:-}"
+  sagename="${SAGENAME:-}"
+
   # If is_restarted is unset, set it to 0.
   if [ -z "$is_restarted" ]; then
     is_restarted=0
@@ -425,11 +431,13 @@ function clean_up() {
 
 # Install Sage theme.
 function install_sage() {
+  sitename="${SITENAME:-}"
+
   # Check if the user is logged into Terminus before trying to run other Terminus commands.
   check_login
 
   themedir="web/app/themes"
-  siteinfo=$(terminus site:info)
+  siteinfo=$(terminus site:info $sitename)
   id=$(get_field "ID" "$siteinfo")
   name=$(get_field "Name" "$siteinfo")
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -406,7 +406,7 @@ function update_composer() {
   echo "${yellow}Waiting for the deploy to finish.${normal}"
   if [ "$is_ci" -eq 1 ]; then
     echo "${yellow}CI detected. We'll need to wait longer.${normal}"
-    waittime=300
+    waittime=180
   else
     waittime=90
   fi

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -396,8 +396,7 @@ function update_composer() {
   git add composer.json
   git commit -m "[Sage Install] Add post-install-cmd hook to also run install on ${sagename}"
 
-  git pull --ff --commit
-  if ! git push origin master; then
+  if ! git push origin master; then+
     echo "${red}Push failed. Stopping here.${normal}"
     echo "Next steps are to push the changes to the repo and then set the connection mode back to Git."
     exit 1;
@@ -424,6 +423,8 @@ function update_composer() {
     echo "${yellow}Workflow still running, waiting another ${waittime} seconds.${normal}"
     terminus workflow:wait --max="$waittime" "$sitename"."$siteenv"
   fi
+
+  git pull --ff --commit
 }
 
 # Finish up the Sage install process.

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -50,6 +50,7 @@ function get_info() {
   sftpuser="${SFTPUSER:-}"
   sftphost="${SFTPHOST:-}"
   sagename="${SAGENAME:-}"
+  is_ci="${CI:-}"
 
   # If is_restarted is unset, set it to 0.
   if [ -z "$is_restarted" ]; then
@@ -60,6 +61,10 @@ function get_info() {
 
   # Unset the variables if we're doing this a second time.
   if [ "$is_restarted" -eq 1 ]; then
+    if [ "$is_ci" -eq 1 ]; then
+      echo "${yellow}CI detected. We're not going to restart. Bailing here.${normal}"
+      exit 1;
+    fi
     unset sitename
     unset sagename
     unset sftpuser

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -235,8 +235,7 @@ function update_php() {
   fi
   if [ "$phpversion" != "8.0" ]; then
     echo "${yellow}You've specified PHP version ${phpversion}. The default is 8.0, but we'll use the version you asked for.${normal}"
-    if [ "$phpversion" == "8.3" ];
-    then
+    if [ "$phpversion" == "8.3" ]; then
       echo "${yellow}PHP 8.3 is not yet supported. Using 8.2 instead.${normal}"
       phpversion="8.2"
     fi

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -377,14 +377,15 @@ function update_composer() {
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OS
-    sed -i '' "s,%sagedir%,$sagedir," composer.new.json
+    if ! sed -i '' "s,%sagedir%,$sagedir," composer.new.json; then
+      echo "${red}Failed to add post-install hook to composer.json. Exiting here.${normal}"
+      exit 1;
   else
     # Linux
-    sed -i "s,%sagedir%,$sagedir," composer.new.json
-  fi
-  if ! sed -i '' "s,%sagedir%,$sagedir," composer.new.json; then
-    echo "${red}Failed to add post-install hook to composer.json. Exiting here.${normal}"
-    exit 1;
+    if ! sed -i "s,%sagedir%,$sagedir," composer.new.json; then
+      echo "${red}Failed to add post-install hook to composer.json. Exiting here.${normal}"
+      exit 1;
+    fi
   fi
 
   rm composer.json

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -270,6 +270,7 @@ function update_php() {
       # Add full PHP version declaration to pantheon.yml.
       echo "php_version: ${phpversion}" >> pantheon.yml
     fi
+    git status
     git commit -am "[Sage Install] Update PHP version to ${phpversion}"
     git push origin "$branch"
   else

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -391,7 +391,7 @@ function update_composer() {
   echo "${yellow}Waiting for the deploy to finish.${normal}"
   if [ "$is_ci" -eq 1 ]; then
     echo "${yellow}CI detected. We'll need to wait longer.${normal}"
-    waittime=600
+    waittime=300
   else
     waittime=90
   fi

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -372,7 +372,19 @@ function update_composer() {
   # Add a post-install hook to the composer.json.
   echo "${yellow}Adding a post-install hook to composer.json.${normal}"
   jq -r '.scripts += { "post-install-cmd": [ "@composer install --no-dev --prefer-dist --ignore-platform-reqs --working-dir=%sagedir%" ] }' composer.json > composer.new.json
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Mac OS
+    sed -i '' "s,%sagedir%,$sagedir," composer.new.json
+  else
+    # Linux
+    sed -i "s,%sagedir%,$sagedir," composer.new.json
+  fi
   sed -i '' "s,%sagedir%,$sagedir," composer.new.json
+  if [ $? -ne 0 ]; then
+    echo "${red}Failed to add post-install hook to composer.json. Exiting here.${normal}"
+    exit 1;
+  fi
+
   rm composer.json
   mv composer.new.json composer.json
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -471,10 +471,10 @@ function clean_up() {
     exit 1;
   fi
 
-  # Switch back to SFTP so files can be written.
-  terminus connection:set "$sitename"."$siteenv" sftp
-
   if [ "$is_ci" -ne 1 ]; then
+    # Switch back to SFTP so files can be written.
+    terminus connection:set "$sitename"."$siteenv" sftp
+
     # Open the site. This should generate requisite files on page load.
     echo "${yellow}Opening the ${siteenv}-${sitename}.pantheonsite.io to generate requisite files.${normal}"
     open https://"$siteenv"-"$sitename".pantheonsite.io

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -149,15 +149,16 @@ function get_info() {
   Theme name: ${sagename}
   SFTP username: ${sftpuser}
   SFTP hostname: ${sftphost}"
-  read -p "Is this correct? (y/n) " -n 1 -r
-  # If the user enters n, redo the prompts.
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Restarting..."
+  if [ "$is_ci" != 1 ]; then
+    read -p "Is this correct? (y/n) " -n 1 -r
+    # If the user enters n, redo the prompts.
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      echo "Restarting..."
 
-    # Toggle the restarted state.
-    is_restarted=1
-
-    get_info
+      # Toggle the restarted state.
+      is_restarted=1
+      get_info
+    fi
   fi
 
   if [ -z "$sitename" ] || [ -z "$sagename" ] || [ -z "$sftpuser" ] || [ -z "$sftphost" ]; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -404,8 +404,9 @@ function update_composer() {
 
   # Check for long-running workflows.
   if [[ "$(terminus workflow:wait --max=1 "${sitename}".dev)" == *"running"* ]]; then
-    echo "${yellow}Workflow still running, waiting another 30 seconds.${normal}"
-    terminus workflow:wait --max=30 "$sitename"."$siteenv"
+    waittime=$(( waittime / 3 ))
+    echo "${yellow}Workflow still running, waiting another ${waittime} seconds.${normal}"
+    terminus workflow:wait --max="$waittime" "$sitename"."$siteenv"
   fi
 }
 


### PR DESCRIPTION
This PR creates a new GH action workflow to test the Sage Theme install script (in `./private/scripts/helpers.sh`) on MacOS and Linux environments (`ubuntu-latest` and `macos-latest`). (Windows tests were attempted but ultimately abandoned due to issues in Terminus and a [lack of support for Windows Terminus installs](https://github.com/pantheon-systems/terminus#ubuntu--winwslubuntu).)

The matrix of tests has been configured to use PHP 8.x versions on each of the OSes it's being tested on (Roots Bedrock does not support < PHP 8).

In addition, changes to the script has been made so it can be run without user input via environment variables. These environment variables can be used to define any of the user input fields as well as whether the script is being run by a CI.

Future improvements could include Windows support (pending official support in the Terminus project), ~~an environment variable for PHP version (so each PHP version in the matrix is actually updated so the created multidev is using that PHP version)~~ (this has been rolled in) ~~and documentation for using the environment variables~~ (documentation has been added), and testing on WordPress multisite.

closes #112