### PR TITLE
[BUGS-7678] add PANTHEON_HOSTNAME to application.pantheon.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,6 +135,9 @@
     "lint:phpcs": [
       "vendor/bin/phpcs -s ."
     ],
+    "lint:phpcbf": [
+      "vendor/bin/phpcbf ."
+    ],
     "lint:bash": [
       "shellcheck private/scripts/*.sh"
     ],

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -13,30 +13,32 @@
 use Roots\WPConfig\Config;
 use function Env\env;
 
-if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && ! isset( $_ENV['LANDO'] ) ) {
-	// We can use PANTHEON_SITE_NAME here because it's safe to assume we're on a Pantheon environment if PANTHEON_ENVIRONMENT is set.
-	$sitename = $_ENV['PANTHEON_SITE_NAME'];
-	$baseurl = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $sitename . '.pantheonsite.io';
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+    if ( ! isset( $_ENV['LANDO'] ) ) {
+        // We can use PANTHEON_SITE_NAME here because it's safe to assume we're on a Pantheon environment if PANTHEON_ENVIRONMENT is set.
+        $sitename = $_ENV['PANTHEON_SITE_NAME'];
+        $baseurl = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $sitename . '.pantheonsite.io';
 
-	$scheme = 'http';
-	if ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ) {
-		$scheme = 'https';
-	}
+        $scheme = 'http';
+        if ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ) {
+            $scheme = 'https';
+        }
 
-	// Define the WP_HOME and WP_SITEURL constants if they aren't already defined.
-	if ( ! env( 'WP_HOME' ) ) {
-		// If HTTP_HOST is set, use that as the base URL. It's probably more accurate.
-		if ( isset( $_SERVER['HTTP_HOST'] ) ) {
-			$baseurl = $_SERVER['HTTP_HOST'];
-		}
+        // Define the WP_HOME and WP_SITEURL constants if they aren't already defined.
+        if ( ! env( 'WP_HOME' ) ) {
+            // If HTTP_HOST is set, use that as the base URL. It's probably more accurate.
+            if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+                $baseurl = $_SERVER['HTTP_HOST'];
+            }
 
-		$homeurl = $scheme . '://' . $baseurl;
-		Config::define( 'WP_HOME', $homeurl );
-		putenv( 'WP_HOME=' . $homeurl );
+            $homeurl = $scheme . '://' . $baseurl;
+            Config::define( 'WP_HOME', $homeurl );
+            putenv( 'WP_HOME=' . $homeurl );
 
-		if ( ! env( 'WP_SITEURL' ) ) {
-			Config::define( 'WP_SITEURL', $homeurl . '/wp' );
-			putenv( 'WP_SITEURL=' . $homeurl . '/wp' );
-		}
-	}
+            if ( ! env( 'WP_SITEURL' ) ) {
+                Config::define( 'WP_SITEURL', $homeurl . '/wp' );
+                putenv( 'WP_SITEURL=' . $homeurl . '/wp' );
+            }
+        }
+    }
 }

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -41,4 +41,11 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
             }
         }
     }
+
+    if ( ! defined('PANTHEON_HOSTNAME' ) ) {
+        $site_name = $_ENV['PANTHEON_SITE_NAME'];
+        $hostname = ! isset( $_SERVER['HTTP_HOST'] ) ? $_ENV['PANTHEON_ENVIRONMENT'] . "-$site_name.pantheonsite.io" : $_SERVER['HTTP_HOST'];
+        $hostname = $_ENV['PANTHEON_ENVIRONMENT'] === 'lando' ? "$site_name.lndo.site" : $hostname;
+        define( 'PANTHEON_HOSTNAME', $hostname );
+    }
 }

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -49,3 +49,8 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		define( 'PANTHEON_HOSTNAME', $hostname );
 	}
 }
+
+// Update the multisite configuration to use Config::define() instead of define.
+add_filter( 'pantheon.multisite.config_contents', function( $config_contents ) {
+    $config_contents = str_replace( 'define(', 'Config::define(', $config_contents );
+} );

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -44,8 +44,8 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 
 	if ( ! defined( 'PANTHEON_HOSTNAME' ) ) {
 		$site_name = $_ENV['PANTHEON_SITE_NAME'];
-		$hostname = ! isset( $_SERVER['HTTP_HOST'] ) ? $_ENV['PANTHEON_ENVIRONMENT'] . "-$site_name.pantheonsite.io" : $_SERVER['HTTP_HOST'];
-		$hostname = $_ENV['PANTHEON_ENVIRONMENT'] === 'lando' ? "$site_name.lndo.site" : $hostname;
+		$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $_ENV['PANTHEON_ENVIRONMENT'] . "-{$site_name}.pantheonsite.io";
+		$hostname = isset( $_ENV['LANDO'] ) ? "{$site_name}.lndo.site" : $hostname;
 		define( 'PANTHEON_HOSTNAME', $hostname );
 	}
 }

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -51,6 +51,7 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 }
 
 // Update the multisite configuration to use Config::define() instead of define.
-add_filter( 'pantheon.multisite.config_contents', function( $config_contents ) {
-    $config_contents = str_replace( 'define(', 'Config::define(', $config_contents );
+add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) {
+	$config_contents = str_replace( 'define(', 'Config::define(', $config_contents );
+	return $config_contents;
 } );

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -14,38 +14,38 @@ use Roots\WPConfig\Config;
 use function Env\env;
 
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
-    if ( ! isset( $_ENV['LANDO'] ) ) {
-        // We can use PANTHEON_SITE_NAME here because it's safe to assume we're on a Pantheon environment if PANTHEON_ENVIRONMENT is set.
-        $sitename = $_ENV['PANTHEON_SITE_NAME'];
-        $baseurl = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $sitename . '.pantheonsite.io';
+	if ( ! isset( $_ENV['LANDO'] ) ) {
+		// We can use PANTHEON_SITE_NAME here because it's safe to assume we're on a Pantheon environment if PANTHEON_ENVIRONMENT is set.
+		$sitename = $_ENV['PANTHEON_SITE_NAME'];
+		$baseurl = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $sitename . '.pantheonsite.io';
 
-        $scheme = 'http';
-        if ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ) {
-            $scheme = 'https';
-        }
+		$scheme = 'http';
+		if ( isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ) {
+			$scheme = 'https';
+		}
 
-        // Define the WP_HOME and WP_SITEURL constants if they aren't already defined.
-        if ( ! env( 'WP_HOME' ) ) {
-            // If HTTP_HOST is set, use that as the base URL. It's probably more accurate.
-            if ( isset( $_SERVER['HTTP_HOST'] ) ) {
-                $baseurl = $_SERVER['HTTP_HOST'];
-            }
+		// Define the WP_HOME and WP_SITEURL constants if they aren't already defined.
+		if ( ! env( 'WP_HOME' ) ) {
+			// If HTTP_HOST is set, use that as the base URL. It's probably more accurate.
+			if ( isset( $_SERVER['HTTP_HOST'] ) ) {
+				$baseurl = $_SERVER['HTTP_HOST'];
+			}
 
-            $homeurl = $scheme . '://' . $baseurl;
-            Config::define( 'WP_HOME', $homeurl );
-            putenv( 'WP_HOME=' . $homeurl );
+			$homeurl = $scheme . '://' . $baseurl;
+			Config::define( 'WP_HOME', $homeurl );
+			putenv( 'WP_HOME=' . $homeurl );
 
-            if ( ! env( 'WP_SITEURL' ) ) {
-                Config::define( 'WP_SITEURL', $homeurl . '/wp' );
-                putenv( 'WP_SITEURL=' . $homeurl . '/wp' );
-            }
-        }
-    }
+			if ( ! env( 'WP_SITEURL' ) ) {
+				Config::define( 'WP_SITEURL', $homeurl . '/wp' );
+				putenv( 'WP_SITEURL=' . $homeurl . '/wp' );
+			}
+		}
+	}
 
-    if ( ! defined('PANTHEON_HOSTNAME' ) ) {
-        $site_name = $_ENV['PANTHEON_SITE_NAME'];
-        $hostname = ! isset( $_SERVER['HTTP_HOST'] ) ? $_ENV['PANTHEON_ENVIRONMENT'] . "-$site_name.pantheonsite.io" : $_SERVER['HTTP_HOST'];
-        $hostname = $_ENV['PANTHEON_ENVIRONMENT'] === 'lando' ? "$site_name.lndo.site" : $hostname;
-        define( 'PANTHEON_HOSTNAME', $hostname );
-    }
+	if ( ! defined( 'PANTHEON_HOSTNAME' ) ) {
+		$site_name = $_ENV['PANTHEON_SITE_NAME'];
+		$hostname = ! isset( $_SERVER['HTTP_HOST'] ) ? $_ENV['PANTHEON_ENVIRONMENT'] . "-$site_name.pantheonsite.io" : $_SERVER['HTTP_HOST'];
+		$hostname = $_ENV['PANTHEON_ENVIRONMENT'] === 'lando' ? "$site_name.lndo.site" : $hostname;
+		define( 'PANTHEON_HOSTNAME', $hostname );
+	}
 }


### PR DESCRIPTION
Adds the new `PANTHEON_HOSTNAME` constant to `application.pantheon.php` so it can be used for configuring multisites and avoid complicated logic.

This PR also implements the `pantheon.multisite.config_contents` filter to correctly update the multisite configuration recommendation.

Finally, this PR adds a `composer lint:phpcbf` helper script to the `composer.json`.