### PR TITLE
Update Sage Test workflow

### DIFF
--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -70,8 +70,12 @@ jobs:
       - name: Get and Set PR number
         id: pr
         run: |
-          pr_num=${{ github.event.pull_request.number }} || "rel"
-          echo "PR_NUM=$pr_num" >> $GITHUB_ENV
+          pr_num=${{ github.event.pull_request.number }}
+          if [ "${pr_num}" == "" ]; then
+            echo "PR_NUM=rel" >> $GITHUB_ENV
+          else
+            echo "PR_NUM=${pr_num}" >> $GITHUB_ENV
+          fi
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Setup PHP

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -9,10 +9,48 @@ on:
       - 'private/scripts/**'
     types: [opened, synchronize, reopened, ready_for_review]
 jobs:
+  apply_upstream_updates:
+    name: Apply Upstream Updates
+    runs-on: ubuntu-latest
+    env:
+      TERM: xterm-256color
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install SSH keys
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Get latest Terminus release
+        run: |
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            echo "☕ Installing Terminus on macOS from Homebrew..."
+            brew install pantheon-systems/external/terminus
+          else
+            echo "💻 Installing Terminus from phar on Linux..."
+            curl -L "https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar" -o terminus
+            chmod +x terminus
+            sudo mv terminus /usr/local/bin/
+          fi
+          # Test that terminus works...
+          terminus --version
+      - name: Validate Pantheon Host Key
+        run: |
+          echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config
+          echo "Host *.drush.in PubkeyAcceptedKeyTypes +ssh-rsa" >> ~/.ssh/config
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+      - name: Log into Terminus
+        run: |
+          terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
+          terminus upstream:updates:apply wpcm-sage-install-tests
   test:
     name: Sage Install Tests
     env:
       TERM: xterm-256color
+    needs: apply_upstream_updates
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -85,10 +123,9 @@ jobs:
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config
           echo "Host *.drush.in PubkeyAcceptedKeyTypes +ssh-rsa" >> ~/.ssh/config
           echo "StrictHostKeyChecking no" >> ~/.ssh/config
-      - name: Log into Terminus and Check for updates
+      - name: Log into Terminus
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
-          terminus upstream:updates:apply "wpcm-sage-install-tests.${multidev_name}" --accept-upstream
       - name: Clone site and create multidev
         run: |
           echo "Cloning site..."

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -3,10 +3,11 @@ permissions:
   pull-requests: read
   contents: read
 on:
-  push:
+  pull_request:
     paths:
       - '.github/workflows/sage-test.yml'
       - 'private/scripts/**'
+    types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   test:
     name: Sage Install Tests

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -32,10 +32,7 @@ jobs:
       - name: Get and Set PR number
         id: pr
         run: |
-          pr_num=$(gh pr view --json number -q .number || echo "")
-          if [[ -z "$pr_num" ]]; then
-            pr_num=rel
-          fi
+          pr_num=$(gh pr view --json number -q .number || echo "rel")
           echo "PR_NUM=$pr_num" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Get and Set PR number
         id: pr
         run: |
-          pr_num=$(gh pr view --json number -q .number || echo "rel")
+          pr_num=${{ github.event.pull_request.number }} || "rel"
           echo "PR_NUM=$pr_num" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Log into Terminus and Check for updates
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
-          terminus upstream:updates:apply wpcm-sage-install-tests.dev --accept-upstream
+          terminus upstream:updates:apply "wpcm-sage-install-tests.${multidev_name}"" --accept-upstream
       - name: Clone site and create multidev
         run: |
           echo "Cloning site..."

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Get and Set PR number
         id: pr
         run: |
-          pr_num=${{ github.event.pull_request.number }}
+          pr_num=${{ github.run_number }}
           if [ "${pr_num}" == "" ]; then
             echo "PR_NUM=rel" >> $GITHUB_ENV
           else

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -32,6 +32,9 @@ jobs:
         id: pr
         run: |
           pr_num=$(gh pr view --json number -q .number || echo "")
+          if [[ -z "$pr_num" ]]; then
+            pr_num=rel
+          fi
           echo "PR_NUM=$pr_num" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -25,18 +25,9 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Get latest Terminus release
-        run: |
-          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            echo "☕ Installing Terminus on macOS from Homebrew..."
-            brew install pantheon-systems/external/terminus
-          else
-            echo "💻 Installing Terminus from phar on Linux..."
-            curl -L "https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar" -o terminus
-            chmod +x terminus
-            sudo mv terminus /usr/local/bin/
-          fi
-          # Test that terminus works...
-          terminus --version
+        uses: pantheon-systems/action-terminus-install@v1
+        with:
+          os: ${{ matrix.os }}
       - name: Validate Pantheon Host Key
         run: |
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config
@@ -110,18 +101,9 @@ jobs:
           echo "Generated multidev name: $multidev_name"
           echo "multidev_name=$multidev_name" >> $GITHUB_ENV
       - name: Get latest Terminus release
-        run: |
-          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            echo "☕ Installing Terminus on macOS from Homebrew..."
-            brew install pantheon-systems/external/terminus
-          else
-            echo "💻 Installing Terminus from phar on Linux..."
-            curl -L "https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar" -o terminus
-            chmod +x terminus
-            sudo mv terminus /usr/local/bin/
-          fi
-          # Test that terminus works...
-          terminus --version
+        uses: pantheon-systems/action-terminus-install@v1
+        with:
+          os: ${{ matrix.os }}
       - name: Validate Pantheon Host Key
         run: |
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Log into Terminus and Check for updates
         run: |
           terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
-          terminus upstream:updates:apply "wpcm-sage-install-tests.${multidev_name}"" --accept-upstream
+          terminus upstream:updates:apply "wpcm-sage-install-tests.${multidev_name}" --accept-upstream
       - name: Clone site and create multidev
         run: |
           echo "Cloning site..."

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -150,12 +150,12 @@ jobs:
           echo "✅ Sage Install Script passed!"
       - name: Delete multidev
         if: always()
-        run: terminus multidev:delete --delete-branch --yes wpcm-sage-install-tests.$multidev_name
+        run: terminus multidev:delete --delete-branch --yes "wpcm-sage-install-tests.${multidev_name}"
       - name: Delete the multidev build artifact
         if: always()
         run: |
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
           # Allow these to fail.
           git fetch --tags origin || true
-          git tag -d pantheon_build_artifacts_$multidev_name || true
-          git push origin --delete pantheon_build_artifacts_$multidev_name || true
+          git tag -d "pantheon_build_artifacts_${multidev_name}" || true
+          git push origin --delete "pantheon_build_artifacts_${multidev_name}" || true


### PR DESCRIPTION
Resolves an issue where Sage Test workflow fails on multidev creation because `{os}-{phpver}-` (e.g. `mac-81-`) is not a valid multidev name.

Some additional changes were made in this workflow to ensure consistency and future debugging. The trigger was updated to `pull_request` from `push` so closing, reopening, or transitions could trigger the workflow. Additionally, the `pr_num` (which is a misnomer now) logic was updated to use the GHA run number instead of the PR number. This way the number is more unique and there is less change of multidev name collisions when subsequent pushes are made to the same PR.

An `Apply Upstream Updates` step was broken out of the workflow and set as a dependency for the Sage tests because it was previously being run inside the matrix of tests. This meant that any test that found upstream updates could fail other tests that are checking for upstream updates at the same time.