### PR TITLE
Remove add_filter from application.pantheon.php

### DIFF
--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -49,9 +49,3 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		define( 'PANTHEON_HOSTNAME', $hostname );
 	}
 }
-
-// Update the multisite configuration to use Config::define() instead of define.
-add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) {
-	$config_contents = str_replace( 'define(', 'Config::define(', $config_contents );
-	return $config_contents;
-} );

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Plugin Name: Pantheon WordPress Filters
+ * Plugin URI:   https://github.com/pantheon-systems/wordpress-composer-managed
+ * Description:  Filters for Composer-managed WordPress sites on Pantheon.
+ * Version:      1.0.0
+ * Author:       Pantheon Systems
+ * Author URI:   https://pantheon.io/
+ * License:      MIT License
+ */
+
+
+/**
+ * Update the multisite configuration to use Config::define() instead of define.
+ *
+ * @return string
+ */
+add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) {
+	$config_contents = str_replace( 'define(', 'Config::define(', $config_contents );
+	return $config_contents;
+} );


### PR DESCRIPTION
This is too early for `add_filter` to be recognized by WordPress. Added back as a mu-plugin.