### PR TITLE
Use `terminus-github-actions` and Sage install script cleanup

### DIFF
--- a/.github/workflows/composer-diff.yml
+++ b/.github/workflows/composer-diff.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           header: composer-diff
           message: |
-            <strong>Composer Changes</strong>
+            <details>
+            <summary><strong>Composer Changes</strong></summary>
 
             ${{ steps.composer_diff.outputs.composer_diff }}
+            </details>

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -157,9 +157,14 @@ jobs:
         run: |
           cd ~/pantheon-local-copies/wpcm-sage-install-tests
           composer update
+      - name: Generate random theme name
+        run: |
+          # Hit https://binaryjazz.us/wp-json/genrenator/v1/genre/ to get a random string we can use as a name.
+          SAGENAME=$(curl -s https://binaryjazz.us/wp-json/genrenator/v1/genre/)
+          echo "SAGENAME=$SAGENAME" >> $GITHUB_ENV
       - name: Run Sage Install Script
         env:
-          SAGENAME: sage-test
+          SAGENAME: ${{ env.SAGENAME }}
           SITENAME: wpcm-sage-install-tests
           CI: 1
           PHPVERSION: ${{ matrix.php-version }}

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Get latest Terminus release
-        uses: pantheon-systems/action-terminus-install@v1
+        uses: pantheon-systems/terminus-github-actions@v1
         with:
-          os: ${{ matrix.os }}
+          pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
       - name: Validate Pantheon Host Key
         run: |
           echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -161,6 +161,8 @@ jobs:
         run: |
           # Hit https://binaryjazz.us/wp-json/genrenator/v1/genre/ to get a random string we can use as a name.
           SAGENAME=$(curl -s https://binaryjazz.us/wp-json/genrenator/v1/genre/)
+          # Replace spaces with hyphens.
+          SAGENAME=$(echo $SAGENAME | tr ' ' '-')
           echo "SAGENAME=$SAGENAME" >> $GITHUB_ENV
       - name: Run Sage Install Script
         env:

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -159,10 +159,10 @@ jobs:
           composer update
       - name: Generate random theme name
         run: |
-          # Hit https://binaryjazz.us/wp-json/genrenator/v1/genre/ to get a random string we can use as a name.
+          # Fetch the genre name from the Genrenator API
           SAGENAME=$(curl -s https://binaryjazz.us/wp-json/genrenator/v1/genre/)
-          # Replace spaces with hyphens.
-          SAGENAME=$(echo $SAGENAME | tr ' ' '-')
+          # Replace spaces with hyphens and remove all non-alphanumeric characters except hyphens
+          SAGENAME=$(echo "$SAGENAME" | tr ' ' '-' | sed 's/[^a-zA-Z0-9\-]//g')
           echo "SAGENAME=$SAGENAME" >> $GITHUB_ENV
       - name: Run Sage Install Script
         env:

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -459,8 +459,6 @@ function update_composer() {
 
 # Finish up the Sage install process.
 function clean_up() {
-  local is_multisite
-
   # List the app/themes directory.
   echo "${yellow}Checking the themes directory for ${sagename}.${normal}"
   # If the previous output did not include $sagename, bail.
@@ -469,11 +467,10 @@ function clean_up() {
     exit 1;
   fi
 
-  echo "${yellow}Checking if this is a multisite.${normal}"
-  is_multisite=$(terminus wp -- "$sitename"."$siteenv" config is-true MULTISITE)
 
   # If the site is multisite, we'll need to enable the theme so we can activate it.
-  if [ "$is_multisite" == 1 ]; then
+  echo "${yellow}Checking if this is a multisite.${normal}"
+  if terminus wp -- "$sitename"."$siteenv" config is-true MULTISITE; then
     echo "${yellow}Site is multisite.${normal}"
     terminus wp -- "$sitename"."$siteenv" theme enable "$sagename"
   fi

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -475,22 +475,23 @@ function clean_up() {
     exit 1;
   fi
 
-  # Switch back to SFTP so files can be written.
-  terminus connection:set "$sitename"."$siteenv" sftp
-
+  # If this is a CI environment, we can skip these steps.
   if [ "$is_ci" -ne 1 ]; then
+    # Switch back to SFTP so files can be written.
+    terminus connection:set "$sitename"."$siteenv" sftp
+
     # Open the site. This should generate requisite files on page load.
     echo "${yellow}Opening the ${siteenv}-${sitename}.pantheonsite.io to generate requisite files.${normal}"
     open https://"$siteenv"-"$sitename".pantheonsite.io
+
+    # Commit any additions found in SFTP mode.
+    echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
+    terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
+
+    # Switch back to Git.
+    terminus connection:set "$sitename"."$siteenv" git
+    git pull --ff --commit
   fi
-
-  # Commit any additions found in SFTP mode.
-  echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
-  terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
-
-  # Switch back to Git.
-  terminus connection:set "$sitename"."$siteenv" git
-  git pull --ff --commit
 }
 
 # Install Sage theme.

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -486,23 +486,26 @@ function clean_up() {
     exit 1;
   fi
 
-  # If this is a CI environment, we can skip these steps.
-  if [ "$is_ci" -ne 1 ]; then
-    # Switch back to SFTP so files can be written.
-    terminus connection:set "$sitename"."$siteenv" sftp
-
-    # Open the site. This should generate requisite files on page load.
-    echo "${yellow}Opening the ${siteenv}-${sitename}.pantheonsite.io to generate requisite files.${normal}"
-    open https://"$siteenv"-"$sitename".pantheonsite.io
-
-    # Commit any additions found in SFTP mode.
-    echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
-    terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
-
-    # Switch back to Git.
-    terminus connection:set "$sitename"."$siteenv" git
-    git pull --ff --commit
+  # If this is a CI environment, stop here.
+  if [ "$is_ci" == 1 ]; then
+    echo "${yellow}CI detected. All done here.${normal} 🍵"
+    exit 0;
   fi
+
+  # Switch back to SFTP so files can be written.
+  terminus connection:set "$sitename"."$siteenv" sftp
+
+  # Open the site. This should generate requisite files on page load.
+  echo "${yellow}Opening the ${siteenv}-${sitename}.pantheonsite.io to generate requisite files.${normal}"
+  open https://"$siteenv"-"$sitename".pantheonsite.io
+
+  # Commit any additions found in SFTP mode.
+  echo "${yellow}Committing any files found in SFTP mode that were created by Sage.${normal}"
+  terminus env:commit "$sitename"."$siteenv" --message="[Sage Install] Add any leftover files found in SFTP mode."
+
+  # Switch back to Git.
+  terminus connection:set "$sitename"."$siteenv" git
+  git pull --ff --commit
 }
 
 # Install Sage theme.

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -468,7 +468,7 @@ function clean_up() {
   is_multisite=$(terminus wp -- "$sitename"."$siteenv" config get MULTISITE)
 
   # If the site is multisite, we'll need to enable the theme so we can activate it.
-  if [ -n "$is_multisite" ]; then
+  if [ "$is_multisite" == 1 ]; then
     echo "${yellow}Site is multisite.${normal}"
     terminus wp -- "$sitename"."$siteenv" theme enable "$sagename"
   fi

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -336,7 +336,8 @@ function add_symlink() {
 
   # Create a files/cache directory on the host if one does not already exist.
   if [ "$(sftp -P 2222 "$sftpuser"@"$sftphost" <<< "ls /files" | grep -c "^cache$")" -eq 0 ]; then
-    sftp -P 2222 "$sftpuser"@"$sftphost" <<EOF
+    sftp -v -P 2222 "$sftpuser"@"$sftphost" <<EOF
+ls /files
 cd /files
 mkdir cache
 EOF

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -452,6 +452,8 @@ function update_composer() {
 
 # Finish up the Sage install process.
 function clean_up() {
+  local is_multisite=""
+
   # List the app/themes directory.
   echo "${yellow}Checking the themes directory for ${sagename}.${normal}"
   # If the previous output did not include $sagename, bail.
@@ -460,8 +462,14 @@ function clean_up() {
     exit 1;
   fi
 
+  is_multisite=$(terminus wp -- "$sitename"."$siteenv" config get MULTISITE)
+
   # If the site is multisite, we'll need to enable the theme so we can activate it.
-  terminus wp -- "$sitename"."$siteenv" theme enable "$sagename"
+  if [ -n "$is_multisite" ]; then
+    echo "${yellow}Site is multisite.${normal}"
+    terminus wp -- "$sitename"."$siteenv" theme enable "$sagename"
+  fi
+
   # List the themes.
   terminus wp -- "$sitename"."$siteenv" theme list
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -318,6 +318,9 @@ function install_sage_theme() {
 
 # Create the symlink to the cache directory.
 function add_symlink() {
+  echo "Waiting for the last step to finish before switching to SFTP mode."
+  terminus workflow:wait "$sitename"."$siteenv"
+
   # Switch to SFTP mode
   terminus connection:set "$sitename"."$siteenv" sftp
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -469,7 +469,7 @@ function clean_up() {
   fi
 
   echo "${yellow}Checking if this site is a multisite.${normal}"
-  is_multisite=$(terminus wp -- "$sitename"."$siteenv" config get MULTISITE)
+  is_multisite=$(terminus wp -- "$sitename"."$siteenv" config is-true MULTISITE)
 
   # If the site is multisite, we'll need to enable the theme so we can activate it.
   if [ "$is_multisite" == 1 ]; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -335,9 +335,10 @@ function add_symlink() {
   fi
 
   # Create a files/cache directory on the host if one does not already exist.
-  if [ "$(sftp -P 2222 "$sftpuser"@"$sftphost" <<< "ls /files" | grep -c "^cache$")" -eq 0 ]; then
-    sftp -v -P 2222 "$sftpuser"@"$sftphost" <<EOF
-ls /files
+  echo "Checking if /files/cache exists..."
+  if [ "$(sftp -P 2222 "$sftpuser"@"$sftphost" <<< "ls /files" | grep -c "/cache[[:space:]]*$")" -eq 0 ]; then
+    echo "Creating /files/cache directory..."
+    sftp -P 2222 "$sftpuser"@"$sftphost" <<EOF
 cd /files
 mkdir cache
 EOF
@@ -468,7 +469,7 @@ function clean_up() {
     exit 1;
   fi
 
-  echo "${yellow}Checking if this site is a multisite.${normal}"
+  echo "${yellow}Checking if this is a multisite.${normal}"
   is_multisite=$(terminus wp -- "$sitename"."$siteenv" config is-true MULTISITE)
 
   # If the site is multisite, we'll need to enable the theme so we can activate it.

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -334,11 +334,13 @@ function add_symlink() {
     mkdir web/app/uploads/cache
   fi
 
-  # Create a files/cache directory on the host.
-  sftp -P 2222 "$sftpuser"@"$sftphost" <<EOF
-    cd /files
-    mkdir cache
+  # Create a files/cache directory on the host if one does not already exist.
+  if [ $(sftp -P 2222 "$sftpuser"@"$sftphost" <<< "ls /files" | grep -c "^cache$") -eq 0 ]; then
+    sftp -P 2222 "$sftpuser"@"$sftphost" <<EOF
+cd /files
+mkdir cache
 EOF
+  fi
 
     # Switch back to Git mode.
     terminus connection:set "$sitename"."$siteenv" git

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -335,7 +335,7 @@ function add_symlink() {
   fi
 
   # Create a files/cache directory on the host if one does not already exist.
-  if [ $(sftp -P 2222 "$sftpuser"@"$sftphost" <<< "ls /files" | grep -c "^cache$") -eq 0 ]; then
+  if [ "$(sftp -P 2222 "$sftpuser"@"$sftphost" <<< "ls /files" | grep -c "^cache$")" -eq 0 ]; then
     sftp -P 2222 "$sftpuser"@"$sftphost" <<EOF
 cd /files
 mkdir cache

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -458,7 +458,7 @@ function update_composer() {
 
 # Finish up the Sage install process.
 function clean_up() {
-  local is_multisite=""
+  local is_multisite
 
   # List the app/themes directory.
   echo "${yellow}Checking the themes directory for ${sagename}.${normal}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -468,6 +468,7 @@ function clean_up() {
     exit 1;
   fi
 
+  echo "${yellow}Checking if this site is a multisite.${normal}"
   is_multisite=$(terminus wp -- "$sitename"."$siteenv" config get MULTISITE)
 
   # If the site is multisite, we'll need to enable the theme so we can activate it.


### PR DESCRIPTION
* replaces (deprecated, duplicate) `pantheon-systems/action-install-terminus` with `pantheon-systems/terminus-github-actions`
* updates the output of the composer-diff comment
* generates a random theme name for the sage install (rather than just `sage-test`)
* adds a wait step before switching to sftp mode for the `add_symlink` step
* checks if the `/files/cache` directory exists before creating it
* updates multisite check logic to use `wp config is-true` (rather than running `theme enable` regardless)
* bails early if running in CI (last several steps are not needed for CI testing)