### PR TITLE
[CMSP-132] shellcheck devops scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
       run: composer update --no-progress --prefer-dist --optimize-autoloader
 
     - name: Run lints
-      run: composer lint
+      run: |
+        composer lint:devops
+        composer lint
 
     - name: Run tests
       run: composer test

--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,8 @@
       "vendor/bin/phpcbf ."
     ],
     "lint:bash": [
-      "shellcheck private/scripts/*.sh"
+      "shellcheck private/scripts/*.sh",
+      "shellcheck devops/scripts/*.sh"
     ],
     "test": [],
     "upstream-require": [

--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
     ],
     "lint:bash": [
       "shellcheck private/scripts/*.sh",
-      "shellcheck devops/scripts/*.sh"
+      "[ -d devops/scripts ] && shellcheck devops/scripts/*.sh"
     ],
     "test": [],
     "upstream-require": [

--- a/composer.json
+++ b/composer.json
@@ -139,7 +139,9 @@
       "vendor/bin/phpcbf ."
     ],
     "lint:bash": [
-      "shellcheck private/scripts/*.sh",
+      "shellcheck private/scripts/*.sh"
+    ],
+    "lint:devops": [
       "[ -d devops/scripts ] && shellcheck devops/scripts/*.sh"
     ],
     "test": [],

--- a/devops/scripts/check-commits.sh
+++ b/devops/scripts/check-commits.sh
@@ -9,9 +9,10 @@ set -euo pipefail
 . devops/scripts/commit-type.sh
 
 # List commits between release-pointer and HEAD, in reverse
+merge_base=""
 merge_base=$(git merge-base default HEAD)
+prcommits=""
 prcommits=$(git log "${merge_base}"..HEAD --pretty=format:"%h")
-
 status=0
 
 # Identify commits that should be released

--- a/devops/scripts/check-commits.sh
+++ b/devops/scripts/check-commits.sh
@@ -9,7 +9,8 @@ set -euo pipefail
 . devops/scripts/commit-type.sh
 
 # List commits between release-pointer and HEAD, in reverse
-prcommits=$(git log "$(git merge-base default HEAD)"..HEAD --pretty=format:"%h")
+merge_base=$(git merge-base default HEAD)
+prcommits=$(git log "${merge_base}"..HEAD --pretty=format:"%h")
 
 status=0
 

--- a/devops/scripts/check-commits.sh
+++ b/devops/scripts/check-commits.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 . devops/scripts/commit-type.sh
 
 # List commits between release-pointer and HEAD, in reverse
-prcommits=$(git log $(git merge-base default HEAD)..HEAD --pretty=format:"%h")
+prcommits=$(git log "$(git merge-base default HEAD)"..HEAD --pretty=format:"%h")
 
 status=0
 

--- a/devops/scripts/commit-type.sh
+++ b/devops/scripts/commit-type.sh
@@ -40,7 +40,8 @@ function only_allowed_files() {
 
   affected_paths=$(git show "${commit}" --pretty=oneline --name-only | tail -n +2)
   for path in $affected_paths; do
-    if [[ " ${forbidden_files[*]} " =~ ${path} ]]; then
+    # shellcheck disable=SC2076
+    if [[ " ${forbidden_files[*]} " =~ " ${path} " ]]; then
       has_forbidden_files=1
       break
     fi

--- a/devops/scripts/commit-type.sh
+++ b/devops/scripts/commit-type.sh
@@ -40,7 +40,7 @@ function only_allowed_files() {
 
   affected_paths=$(git show "${commit}" --pretty=oneline --name-only | tail -n +2)
   for path in $affected_paths; do
-    if [[ " ${forbidden_files[*]} " =~ " ${path} " ]]; then
+    if [[ " ${forbidden_files[*]} " =~ ${path} ]]; then
       has_forbidden_files=1
       break
     fi

--- a/devops/scripts/decoupledpatch.sh
+++ b/devops/scripts/decoupledpatch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SED=`which gsed || which sed`
+SED=$(which gsed || which sed)
 
 $SED -i'' 's#"name": "pantheon-systems/wordpress-composer-managed"#"name": "pantheon-upstreams/decoupled-wordpress-composer-managed"#g' composer.json
 

--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -102,7 +102,7 @@ for commit in "${commits[@]}"; do
 done
 
 echo "Executing decoupledpatch.sh"
-# shellcheck disable=SC1091
+# shellcheck source=devops/scripts/decoupledpatch.sh
 . /tmp/decoupledpatch.sh
 
 echo "Copying README to docroot."

--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -40,7 +40,7 @@ for commit in $newcommits; do
   # Exclude commits which have been manually rejected
   skip=false
   for item in "${exclude_list[@]}"; do
-    if [[ $item == $commit ]]; then
+    if [[ $item == "$commit" ]]; then
       echo "Commit ${commit} has been manually excluded."
       skip=true
     fi
@@ -52,17 +52,18 @@ for commit in $newcommits; do
 
   commit_type=$(identify_commit_type "$commit")
   if [[ $commit_type == "normal" ]] ; then
-    commits+=($commit)
+    commits+=("$commit")
   fi
 
   if [[ $commit_type == "mixed" ]] ; then
     2>&1 echo "Commit ${commit} contains both release and nonrelease changes. Skipping this commit."
     echo "You may wish to ensure that nothing in this commit is meant for release."
-    delete=(${commit})
+    delete=("${commit}")
     for remove in "${delete[@]}"; do
       if (( ${#commits[@]} )); then
+        # shellcheck disable=SC2034
         for i in "${commits[@]}"; do
-          if [[ ${commits[0]} = $remove ]]; then
+          if [[ ${commits[0]} = "$remove" ]]; then
             unset 'commits[i]'
           fi
         done
@@ -101,6 +102,7 @@ for commit in "${commits[@]}"; do
 done
 
 echo "Executing decoupledpatch.sh"
+# shellcheck disable=SC1091
 . /tmp/decoupledpatch.sh
 
 echo "Copying README to docroot."
@@ -118,7 +120,7 @@ echo
 # Push to the decoupled repository
 git push decoupled decoupled:main
 
-git checkout $CIRCLE_BRANCH
+git checkout "$CIRCLE_BRANCH"
 
 # update the decoupled-release-pointer
 git tag -f -m 'Last commit set on upstream repo' decoupled-release-pointer HEAD

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -32,7 +32,7 @@ commits=()
 for commit in $newcommits; do
   commit_type=$(identify_commit_type "$commit")
   if [[ $commit_type == "normal" ]] ; then
-    commits+=($commit)
+    commits+=("$commit")
     continue
   fi
 
@@ -87,7 +87,7 @@ echo
 # Push to the public repository
 git push public public:main
 
-git checkout $CIRCLE_BRANCH
+git checkout "$CIRCLE_BRANCH"
 
 # update the release-pointer
 git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD


### PR DESCRIPTION
This pull request updates the linting Composer scripts in the project and adds a new `lint:devops` script to be used in automation and Pantheon engineers. It makes sure that only existing devops scripts are linted.

This PR also updates the scripts to shellcheck standards.