### PR TITLE
[CMSP-150] Update wp-config filename to use `config/application.php`

### DIFF
--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -19,3 +19,13 @@ add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) 
 	$config_contents = str_replace( 'define(', 'Config::define(', $config_contents );
 	return $config_contents;
 } );
+
+/**
+ * Update the wp-config filename to use config/application.php.
+ *
+ * @return string
+ */
+add_filter( 'pantheon.multisite.config_filename', function ( $config_filename ) {
+    $config_filename = 'config/application.php';
+    return $config_filename;
+} );

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -26,6 +26,5 @@ add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) 
  * @return string
  */
 add_filter( 'pantheon.multisite.config_filename', function ( $config_filename ) {
-    $config_filename = 'config/application.php';
-    return $config_filename;
+    return 'config/application.php';
 } );


### PR DESCRIPTION
This pull request updates the wp-config filename to use `config/application.php`. This change ensures that the correct filename is used on the WPMS network setup page.
<img width="1081" alt="Screenshot 2024-06-04 at 11 55 50 AM" src="https://github.com/pantheon-systems/wordpress-composer-managed/assets/991511/8a666b65-f459-44cd-9b7a-5245e567eb1e">
