### PR TITLE
Release PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2024-06-04
+* Filters the configuration file filename on the Setup Network instructions page to use `config/application.php` instead of `wp-config.php`. ([#125](https://github.com/pantheon-systems/wordpress-composer-managed/pull/125))
+
 ### 2024-04-30
 * Adds a new `PANTHEON_HOSTNAME` constant to `application.pantheon.php` to be used for configuring multisites. For more information, see our [mulstisite configuration documentation](https://docs.pantheon.io/guides/multisite/config). ([#119](https://github.com/pantheon-systems/wordpress-composer-managed/pull/119))
 * Implements `pantheon.multisite.config_contents` filter to correct the multisite configuration instructions (to use `Config::define` instead of `define`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2024-06-04
 * Filters the configuration file filename on the Setup Network instructions page to use `config/application.php` instead of `wp-config.php`. ([#125](https://github.com/pantheon-systems/wordpress-composer-managed/pull/125))
+* Adds Composer script to update the `platform.php` value to the version of PHP consistent with the version in the `pantheon.yml` file. ([#127](https://github.com/pantheon-systems/wordpress-composer-managed/pull/127)
 
 ### 2024-04-30
 * Adds a new `PANTHEON_HOSTNAME` constant to `application.pantheon.php` to be used for configuring multisites. For more information, see our [mulstisite configuration documentation](https://docs.pantheon.io/guides/multisite/config). ([#119](https://github.com/pantheon-systems/wordpress-composer-managed/pull/119))


### PR DESCRIPTION
Release PR for WPCM update.

Updates changelog and commit message:


> Updates the configuration file filename on the Create a Network of WordPress Sites multisite setup page to use config/application.php instead of wp-config.php. Also adds a Composer script to update the platform PHP version in the composer.json file to match the version of PHP in the pantheon.yml. For more information, see: https://docs.pantheon.io/release-notes/2024/06/pantheon-mu-plugin-1-4-4-wordpress-composer-managed-update
