### PR TITLE
[CMSP-204] Run composer.json update script on preUpdate event

### DIFF
--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -18,6 +18,7 @@ class ComposerScripts
     */
     public static function preUpdate(Event $event)
     {
+        static::applyComposerJsonUpdates($event);
     }
 
     /**


### PR DESCRIPTION
This pull request adds a call to the `applyComposerJsonUpdates` method in the `preUpdate` event of the `ComposerScripts` class. This ensures that the composerjson update script is run when the event is triggered.

This will run the `platform.php` update if `pantheon.yml` has a different version than the PHP version installed. This code already existed in the ComposerScripts file but was not being run.

See source in Drupal Composer Managed: https://github.com/pantheon-systems/drupal-composer-managed/blob/default/upstream-configuration/scripts/ComposerScripts.php#L120-L180