### PR TITLE
fix: ensure managed wordpress files aren't omitted 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ web/.htaccess
 # explicitly.
 web/license.txt
 web/readme.html
-web/index.php
 web/wp-*
+!web/index.php
 !web/wp-cli.yml
 !web/wp-config.php
 !web/wp-config-pantheon.php

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,8 @@ web/.htaccess
 # explicitly.
 web/license.txt
 web/readme.html
+web/index.php
 web/wp-*
-!web/index.php
 !web/wp-cli.yml
 !web/wp-config.php
 !web/wp-config-pantheon.php

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ web/index.php
 web/wp-*
 !web/wp-cli.yml
 !web/wp-config.php
-!web/wp-config.pantheon.php
+!web/wp-config-pantheon.php
 web/xmlrpc.php
 
 # Logfiles should always be ignored.

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ web/license.txt
 web/readme.html
 web/index.php
 web/wp-*
+!web/wp-cli.yml
+!web/wp-config.php
+!web/wp-config.pantheon.php
 web/xmlrpc.php
 
 # Logfiles should always be ignored.


### PR DESCRIPTION
Fixes an issue where the following vcs controlled files were being ignored

The composer post install script is set to create symlinks from the `wp` to `web` folder, however the following files are not present in the original wp folder

```md
!web/wp-cli.yml
!web/wp-config.php
!web/wp-config-pantheon.php
```

