### PR TITLE
replace `tput` with a `safe_tput` function

### DIFF
--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -318,6 +318,7 @@ function install_sage_theme() {
   # Commit the theme
   git add "$sagedir"
   git commit -m "[Sage Install] Add the Sage theme ${sagename}."
+  git push
   echo "${green}Sage installed!${normal}"
 }
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -2,17 +2,22 @@
 set -o pipefail
 IFS=$'\n\t'
 
-# Defines some global variables for colors.
-normal=$(tput sgr0)
-bold=$(tput bold)
-red=$(tput setaf 1)
-green=$(tput setaf 2)
-yellow=$(tput setaf 3)
+# Function to safely call tput
+safe_tput() {
+  tput "$@" 2>/dev/null || echo ""
+}
+
+# Defines some global variables for colors with fallback values.
+normal=$(safe_tput sgr0)
+bold=$(safe_tput bold)
+red=$(safe_tput setaf 1)
+green=$(safe_tput setaf 2)
+yellow=$(safe_tput setaf 3)
 # Additional styles we aren't currently using.
-# italic=$(tput sitm)
-#blue=$(tput setaf 4)
-#magenta=$(tput setaf 5)
-#cyan=$(tput setaf 6)
+#italic=$(safe_tput sitm)
+#blue=$(safe_tput setaf 4)
+#magenta=$(safe_tput setaf 5)
+#cyan=$(safe_tput setaf 6)
 
 # Use environment variables if set, otherwise prompt for input
 sitename="${SITENAME:-}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 # Function to safely call tput
 safe_tput() {
-  tput "$@" 2>/dev/null || echo ""
+  tput "$@" 2>/dev/null
 }
 
 # Defines some global variables for colors with fallback values.


### PR DESCRIPTION
This PR fixes a bug that appears in Workflow logs in the Pantheon dashboard.

<img width="1125" alt="Screenshot 2024-06-25 at 10 12 28 AM" src="https://github.com/pantheon-systems/wordpress-composer-managed/assets/991511/f65e8d12-f6c7-44c8-962d-ab8dde7ac280">

The terminal environment used to render the workflow logs does not support `tput` and does not have a `$TERM` value, so setting the colors at the top of `helpers.sh` throws errors.

The `safe_tput` function allows `tput` to be used on systems that support it but does not error if `tput` is not available. In the cases when this is running (e.g. in Workflow logs) the colors are not really important and are only used when the symlinks are being created during `composer install`.

This PR also adds a `git push` after the Sage theme is built and installed because the script waits for an operation (e.g. `sync_code`) that isn't actually running. This is likely something that was removed but we still have the `workflow:wait` command in place.