### PR TITLE
[CMSP-1140] Fix core resource URLs for non-main sites in subdirectory multisite network

### DIFF
--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -74,12 +74,12 @@ function fix_core_resource_urls( $url ) {
 
 // Only run the filter on non-main sites in a subdirectory multisite network.
 if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
-    add_filter( 'script_loader_src', 'fix_core_resource_urls', 10 );
-    add_filter( 'style_loader_src', 'fix_core_resource_urls', 10 );
-    add_filter( 'plugins_url', 'fix_core_resource_urls', 10 );
-    add_filter( 'theme_file_uri', 'fix_core_resource_urls', 10 );
-    add_filter( 'stylesheet_directory_uri', 'fix_core_resource_urls', 10 );
-    add_filter( 'template_directory_uri', 'fix_core_resource_urls', 10 );
-    add_filter( 'site_url', 'fix_core_resource_urls', 10 );
-    add_filter( 'content_url', 'fix_core_resource_urls', 10 );
+    add_filter( 'script_loader_src', 'fix_core_resource_urls', 9 );
+    add_filter( 'style_loader_src', 'fix_core_resource_urls', 9 );
+    add_filter( 'plugins_url', 'fix_core_resource_urls', 9 );
+    add_filter( 'theme_file_uri', 'fix_core_resource_urls', 9 );
+    add_filter( 'stylesheet_directory_uri', 'fix_core_resource_urls', 9 );
+    add_filter( 'template_directory_uri', 'fix_core_resource_urls', 9 );
+    add_filter( 'site_url', 'fix_core_resource_urls', 9 );
+    add_filter( 'content_url', 'fix_core_resource_urls', 9 );
 }

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -74,12 +74,17 @@ function fix_core_resource_urls( $url ) {
 
 // Only run the filter on non-main sites in a subdirectory multisite network.
 if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
-    add_filter( 'script_loader_src', 'fix_core_resource_urls', 9 );
-    add_filter( 'style_loader_src', 'fix_core_resource_urls', 9 );
-    add_filter( 'plugins_url', 'fix_core_resource_urls', 9 );
-    add_filter( 'theme_file_uri', 'fix_core_resource_urls', 9 );
-    add_filter( 'stylesheet_directory_uri', 'fix_core_resource_urls', 9 );
-    add_filter( 'template_directory_uri', 'fix_core_resource_urls', 9 );
-    add_filter( 'site_url', 'fix_core_resource_urls', 9 );
-    add_filter( 'content_url', 'fix_core_resource_urls', 9 );
+$filters = [
+    'script_loader_src',
+    'style_loader_src',
+    'plugins_url',
+    'theme_file_uri',
+    'stylesheet_directory_uri',
+    'template_directory_uri',
+    'site_url',
+    'content_url'
+];
+foreach ( $filters as $filter ) {
+    add_filter( $filter, 'fix_core_resource_urls', 9 );
+}
 }

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -28,3 +28,58 @@ add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) 
 add_filter( 'pantheon.multisite.config_filename', function ( $config_filename ) {
     return 'config/application.php';
 } );
+
+/**
+ * Correct core resource URLs for non-main sites in a subdirectory multisite network.
+ *
+ * @param string $url The URL to fix.
+ * @return string The fixed URL.
+ */
+function fix_core_resource_urls( $url ) {
+    $main_site_url = trailingslashit( network_site_url( '/' ) );
+    $current_site_path = trailingslashit( get_blog_details()->path );
+
+    // Parse the URL to get its components.
+    $parsed_url = parse_url( $url );
+
+    // If there is no path in the URL, return it as is.
+    if ( ! isset( $parsed_url['path'] ) || $parsed_url['path'] === '/' ) {
+        return $url;
+    }
+
+    // Extract the path from the parsed URL.
+    $path = $parsed_url['path'];
+
+    // Correct the path for core resources.
+    if ( strpos( $path, $current_site_path . 'wp-includes/' ) !== false ) {
+        $path = str_replace( $current_site_path . 'wp-includes/', 'wp-includes/', $path );
+    } elseif ( strpos( $path, $current_site_path . 'wp-admin/' ) !== false ) {
+        $path = str_replace( $current_site_path . 'wp-admin/', 'wp-admin/', $path );
+    } elseif ( strpos( $path, $current_site_path . 'wp-content/' ) !== false ) {
+        $path = str_replace( $current_site_path . 'wp-content/', 'wp-content/', $path );
+    } else {
+        return $url; // Return the original URL if no changes were needed.
+    }
+
+    // Prepend the main site URL to the modified path.
+    $new_url = $main_site_url . ltrim( $path, '/' );
+
+    // Append any query strings if they existed in the original URL.
+    if ( isset( $parsed_url['query'] ) ) {
+        $new_url .= '?' . $parsed_url['query'];
+    }
+
+    return $new_url;
+}
+
+// Only run the filter on non-main sites in a subdirectory multisite network.
+if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
+    add_filter( 'script_loader_src', 'fix_core_resource_urls', 10 );
+    add_filter( 'style_loader_src', 'fix_core_resource_urls', 10 );
+    add_filter( 'plugins_url', 'fix_core_resource_urls', 10 );
+    add_filter( 'theme_file_uri', 'fix_core_resource_urls', 10 );
+    add_filter( 'stylesheet_directory_uri', 'fix_core_resource_urls', 10 );
+    add_filter( 'template_directory_uri', 'fix_core_resource_urls', 10 );
+    add_filter( 'site_url', 'fix_core_resource_urls', 10 );
+    add_filter( 'content_url', 'fix_core_resource_urls', 10 );
+}

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -47,19 +47,21 @@ function fix_core_resource_urls( $url ) {
         return $url;
     }
 
-    // Extract the path from the parsed URL.
-    $path = $parsed_url['path'];
+$core_paths = [ 'wp-includes/', 'wp-admin/', 'wp-content/' ];
+$path_modified = false;
 
-    // Correct the path for core resources.
-    if ( strpos( $path, $current_site_path . 'wp-includes/' ) !== false ) {
-        $path = str_replace( $current_site_path . 'wp-includes/', 'wp-includes/', $path );
-    } elseif ( strpos( $path, $current_site_path . 'wp-admin/' ) !== false ) {
-        $path = str_replace( $current_site_path . 'wp-admin/', 'wp-admin/', $path );
-    } elseif ( strpos( $path, $current_site_path . 'wp-content/' ) !== false ) {
-        $path = str_replace( $current_site_path . 'wp-content/', 'wp-content/', $path );
-    } else {
-        return $url; // Return the original URL if no changes were needed.
+foreach ( $core_paths as $core_path ) {
+    if ( strpos( $path, $current_site_path . $core_path ) !== false ) {
+        $path = str_replace( $current_site_path . $core_path, $core_path, $path );
+        $path_modified = true;
+        break;
     }
+}
+
+// If the path was not modified, return the original URL.
+if ( ! $path_modified ) {
+    return $url;
+}
 
     // Prepend the main site URL to the modified path.
     $new_url = $main_site_url . ltrim( $path, '/' );


### PR DESCRIPTION
This pull request fixes the issue with core resource URLs for non-main sites in a subdirectory multisite network. Previously, the URLs were not being correctly adjusted, causing broken links to core resources (like CSS or JavaScript files). This PR adds a filter function `fix_core_resource_urls` that corrects the URLs by replacing the current site path with the main site URL. The filter is only applied to non-main sites in a subdirectory multisite network.

This problem comes from the custom directory structure used by Roots Bedrock. All the filter hooks are set to priority `9` so they can be easily overridden downstream.