### PR TITLE
Update PHP version to 8.1 and other updates to `helpers.sh`

### DIFF
--- a/.github/fixtures/pantheon-74.yml
+++ b/.github/fixtures/pantheon-74.yml
@@ -1,0 +1,4 @@
+# Put overrides to your pantheon.upstream.yml file here.
+# For more information, see: https://pantheon.io/docs/pantheon-yml/
+api_version: 1
+php_version: 7.4

--- a/.github/fixtures/pantheon-8.yml
+++ b/.github/fixtures/pantheon-8.yml
@@ -1,0 +1,4 @@
+# Put overrides to your pantheon.upstream.yml file here.
+# For more information, see: https://pantheon.io/docs/pantheon-yml/
+api_version: 1
+php_version: 8

--- a/.github/fixtures/pantheon-80.yml
+++ b/.github/fixtures/pantheon-80.yml
@@ -1,0 +1,4 @@
+# Put overrides to your pantheon.upstream.yml file here.
+# For more information, see: https://pantheon.io/docs/pantheon-yml/
+api_version: 1
+php_version: 8.0

--- a/.github/fixtures/pantheon-81.yml
+++ b/.github/fixtures/pantheon-81.yml
@@ -1,0 +1,4 @@
+# Put overrides to your pantheon.upstream.yml file here.
+# For more information, see: https://pantheon.io/docs/pantheon-yml/
+api_version: 1
+php_version: 8.1

--- a/.github/fixtures/pantheon-82.yml
+++ b/.github/fixtures/pantheon-82.yml
@@ -1,0 +1,4 @@
+# Put overrides to your pantheon.upstream.yml file here.
+# For more information, see: https://pantheon.io/docs/pantheon-yml/
+api_version: 1
+php_version: 8.2

--- a/.github/fixtures/pantheon-83.yml
+++ b/.github/fixtures/pantheon-83.yml
@@ -1,0 +1,4 @@
+# Put overrides to your pantheon.upstream.yml file here.
+# For more information, see: https://pantheon.io/docs/pantheon-yml/
+api_version: 1
+php_version: 8.3

--- a/.github/tests/1-test-update-php.bats
+++ b/.github/tests/1-test-update-php.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+custom_setup() {
+  local version=$1
+  # Print debugging information
+  echo "BATS_TEST_DIRNAME: $BATS_TEST_DIRNAME"
+  echo "Current directory before cd: $(pwd)"
+
+  # Check if the .github directory exists
+  if [ ! -d ".github" ]; then
+    echo "Error: .github directory not found in $(pwd)"
+    exit 1
+  fi
+
+  if [ ! -f "pantheon.upstream.yml" ]; then
+    echo "It doesn't look like you are in an upstream repository. Check the current directory: $(pwd)"
+    exit 1
+  fi
+
+  # Copy the fixture file to pantheon.yml before each test
+  cp ".github/fixtures/pantheon-${version}.yml" pantheon.yml
+}
+
+teardown() {
+  # Clean up by removing the pantheon.yml file after each test
+  rm -f pantheon.yml
+}
+
+@test "Update PHP version 7.4 to 8.1" {
+  custom_setup "74"
+  run bash private/scripts/helpers.sh update_php
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run grep -q "php_version: 8.1" pantheon.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "Update PHP version 8.0 to 8.1" {
+  custom_setup "80"
+  run bash private/scripts/helpers.sh update_php
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run grep -q "php_version: 8.1" pantheon.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "Keep PHP version 8.1" {
+  custom_setup "81"
+  run bash private/scripts/helpers.sh update_php
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run grep -q "php_version: 8.1" pantheon.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "Keep PHP version 8.2" {
+  custom_setup "82"
+  run bash private/scripts/helpers.sh update_php
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run grep -q "php_version: 8.2" pantheon.yml
+  [ "$status" -eq 0 ]
+}
+
+@test "Keep PHP version 8.3" {
+  custom_setup "83"
+  run bash private/scripts/helpers.sh update_php
+  echo "$output"
+  [ "$status" -eq 0 ]
+  run grep -q "php_version: 8.3" pantheon.yml
+  [ "$status" -eq 0 ]
+}

--- a/.github/tests/1-test-update-php.bats
+++ b/.github/tests/1-test-update-php.bats
@@ -4,7 +4,7 @@ custom_setup() {
   local version=$1
   # Print debugging information
   echo "BATS_TEST_DIRNAME: $BATS_TEST_DIRNAME"
-  echo "Current directory before cd: $(pwd)"
+  echo "Current directory: $(pwd)"
 
   # Check if the .github directory exists
   if [ ! -d ".github" ]; then
@@ -19,6 +19,12 @@ custom_setup() {
 
   # Copy the fixture file to pantheon.yml before each test
   cp ".github/fixtures/pantheon-${version}.yml" pantheon.yml
+
+  if [ ! -f "pantheon.yml" ]; then
+    echo "Failed to copy the fixture file to $(pwd)/pantheon.yml"
+  else
+    cat pantheon.yml
+  fi
 }
 
 teardown() {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+    contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,12 @@ jobs:
 
     - name: Run tests
       run: composer test
+
+    - name: Install bats
+      uses: bats-core/bats-action@2.0.0
+
+    - name: Test Helper functions
+      env:
+        CI: 1
+      run: |
+          bats -p -t .github/tests

--- a/.github/workflows/sage-test.yml
+++ b/.github/workflows/sage-test.yml
@@ -162,7 +162,7 @@ jobs:
           # Fetch the genre name from the Genrenator API
           SAGENAME=$(curl -s https://binaryjazz.us/wp-json/genrenator/v1/genre/)
           # Replace spaces with hyphens and remove all non-alphanumeric characters except hyphens
-          SAGENAME=$(echo "$SAGENAME" | tr ' ' '-' | sed 's/[^a-zA-Z0-9\-]//g')
+          SAGENAME=$(echo "$SAGENAME" | tr ' ' '-' | tr -cd 'a-zA-Z0-9-')
           echo "SAGENAME=$SAGENAME" >> $GITHUB_ENV
       - name: Run Sage Install Script
         env:

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -484,7 +484,7 @@ function clean_up() {
   # Get the themes.
   themelist=$(terminus wp -- "$sitename"."$siteenv" theme list --format=csv | tr -d '\n' | tr -d ' ')
 
-  if ! echo "$themelist" | grep -q -E "(^|,)$sagename($|,)"; then
+  if ! echo "$themelist" | grep -q "$sagename"; then
     echo "${red}Theme $sagename not found in the theme list. Exiting here.${normal}"
     echo "$themelist"
     exit 1;

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -274,13 +274,13 @@ function update_php() {
   fi
 
   # If we're in CI, don't run the push actions. Note: if you're running Bats tests locally, you should pass CI=1 before running the tests.
-  if [ "$is_ci" -eq 1 ]; then
+  if [ "$is_ci" -eq 0 ]; then
+    git add pantheon.yml
+    git commit -m "[Sage Install] Update PHP version to ${phpversion}"
+    git push origin "$branch"
+  else
     echo "${yellow}CI detected. Skipping Git operations. PHP updated to ${phpversion}.${normal}"
-    exit 0
   fi
-  git add pantheon.yml
-  git commit -m "[Sage Install] Update PHP version to ${phpversion}"
-  git push origin "$branch"
 }
 
 # Install sage and related dependencies.

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -236,11 +236,12 @@ get_field() {
 
 # Update to PHP 8.1 or higher
 function update_php() {
+  # If an old PHP version was passed into the script from the outside, fall back to 8.1.
   if [ "$phpversion" == "8" ] || [ "$phpversion" == "8.0" ]; then
     phpversion="8.1"
   fi
 
-  # Check if $phpversion is < 8.1.
+  # Check if $phpversion is < 8.1. We shouldn't get here because we just updated $phpversion (which is passed from the environment), so if we are here, it's a problem.
   if [ "$(echo "$phpversion < 8.1" | bc)" -eq 1 ]; then
     echo "${red}PHP version must be 8.1 or greater. Exiting here.${normal}"
     exit 1
@@ -267,10 +268,12 @@ function update_php() {
     # Update the PHP version declaration if it's less than 8.1.
     sed -i '' "s/php_version: [0-9.]*/php_version: ${phpversion}/" pantheon.yml
   else
+    # We've got a good PHP version, so we can bail here.
     echo "${green}PHP version is already ${currentPhpVersion} which is >= 8.1.${normal}"
     exit 0
   fi
 
+  # If we're in CI, don't run the push actions. Note: if you're running Bats tests locally, you should pass CI=1 before running the tests.
   if [ "$is_ci" -eq 1  ]; then
     echo "${yellow}CI detected. Skipping Git operations. PHP updated to ${phpversion}."
     exit 0

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -266,7 +266,7 @@ function update_php() {
     echo "php_version: ${phpversion}" >> pantheon.yml
   elif [ "$(echo "$currentPhpVersion < 8.1" | bc)" -eq 1 ]; then
     # Update the PHP version declaration if it's less than 8.1.
-    sed -i '' "s/php_version: [0-9.]*/php_version: ${phpversion}/" pantheon.yml
+    sed -i.bak "s/php_version: [0-9.]*/php_version: ${phpversion}/" pantheon.yml && rm pantheon.yml.bak
   else
     # We've got a good PHP version, so we can bail here.
     echo "${green}PHP version is already ${currentPhpVersion} which is >= 8.1.${normal}"
@@ -274,8 +274,8 @@ function update_php() {
   fi
 
   # If we're in CI, don't run the push actions. Note: if you're running Bats tests locally, you should pass CI=1 before running the tests.
-  if [ "$is_ci" -eq 1  ]; then
-    echo "${yellow}CI detected. Skipping Git operations. PHP updated to ${phpversion}."
+  if [ "$is_ci" -eq 1 ]; then
+    echo "${yellow}CI detected. Skipping Git operations. PHP updated to ${phpversion}.${normal}"
     exit 0
   fi
   git add pantheon.yml

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -247,7 +247,7 @@ function update_php() {
   fi
 
   echo ""
-  echo "${yellow}Updating PHP version to ${phpversion}.${normal}"
+  echo "${yellow}Checking PHP version and maybe updating to ${phpversion}.${normal}"
 
   # Check for pantheon.yml file.
   if [ ! -f "pantheon.yml" ]; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -482,7 +482,7 @@ function clean_up() {
   fi
 
   # Get the themes.
-  themelist=$(terminus wp -- "$sitename"."$siteenv" theme list --format=csv)
+  themelist=$(terminus wp -- "$sitename"."$siteenv" theme list --format=csv | tr -d '\n' | tr -d ' ')
 
   if ! echo "$themelist" | grep -w "^sagename"; then
     echo "${red}Theme $sagename not found in the theme list. Exiting here.${normal}"

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -486,7 +486,7 @@ function clean_up() {
 
   if ! echo "$themelist" | grep -w "^sagename"; then
     echo "${red}Theme $sagename not found in the theme list. Exiting here.${normal}"
-    terminus wp -- "$sitename"."$siteenv" theme list
+    echo "$themelist"
     exit 1;
   fi
 

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -38,7 +38,8 @@ function main() {
   help_msg="Usage: bash ./private/scripts/helpers.sh <command>
   Available commands:
     install_sage: Install Sage.
-    maybe_create_symlinks: Create a symlinks to WordPress files, if they don't already exist."
+    maybe_create_symlinks: Create a symlinks to WordPress files, if they don't already exist.
+    update_php: Updates PHP version to 8.1 if it's not already set at 8.1 or higher."
 
   if [ -z "$1" ]; then
     echo "${red}No command specified.${normal}"
@@ -52,7 +53,7 @@ function main() {
   fi
 
   # Check for a valid command.
-  if [ "$1" != "install_sage" ] && [ "$1" != "maybe_create_symlinks" ]; then
+  if [ "$1" != "install_sage" ] && [ "$1" != "maybe_create_symlinks" ] && [ "$1" != "update_php" ]; then
     echo "${red}Invalid command specified.${normal}"
     echo "${help_msg}"
     exit 1;

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -486,20 +486,16 @@ function clean_up() {
 
   if ! echo "$themelist" | grep -q "$sagename"; then
     echo "${red}Theme $sagename not found in the theme list. Exiting here.${normal}"
-    echo "$themelist"
-    exit 1;
-  fi
-
-  # Activate the new theme
-  echo "${yellow}Activating the ${sagename} theme.${normal}"
-  if ! terminus wp -- "$sitename"."$siteenv" theme activate "$sagename"; then
     terminus wp -- "$sitename"."$siteenv" theme list
-    echo "${red}Theme activation failed. Exiting here.${normal}"
     echo "Check the theme list above. If the theme you created is not listed, it's possible that the deploy has not completed. You can try again in a few minutes using the following command:"
     echo "terminus wp -- $sitename.dev theme activate $sagename"
     echo "Once you do this, you will need to open the site to generate the requisite files and then commit them in SFTP mode."
     exit 1;
   fi
+
+  # Activate the new theme
+  echo "${yellow}Activating the ${sagename} theme.${normal}"
+  terminus wp -- "$sitename"."$siteenv" theme activate "$sagename"
 
   # If this is a CI environment, stop here.
   if [ "$is_ci" == 1 ]; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -24,7 +24,7 @@ sitename="${SITENAME:-}"
 sftpuser="${SFTPUSER:-}"
 sftphost="${SFTPHOST:-}"
 sagename="${SAGENAME:-}"
-phpversion="${PHPVERSION:-8.0}"
+phpversion="${PHPVERSION:-8.1}"
 is_ci="${CI:-0}"
 siteenv="${SITEENV:-dev}"
 if [ "$siteenv" == "dev" ]; then

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -484,7 +484,7 @@ function clean_up() {
   # Get the themes.
   themelist=$(terminus wp -- "$sitename"."$siteenv" theme list --format=csv | tr -d '\n' | tr -d ' ')
 
-  if ! echo "$themelist" | grep -w "^sagename"; then
+  if ! echo "$themelist" | grep -q -E "(^|,)$sagename($|,)"; then
     echo "${red}Theme $sagename not found in the theme list. Exiting here.${normal}"
     echo "$themelist"
     exit 1;


### PR DESCRIPTION
This PR updates the `helpers.sh` script's `update_php` function to default to a minimum of PHP 8.1 since Sage no longer supports 8.0.

The update_php function has therefore been updated to check for a minimum of 8.1 but _additionally_ updates have been made so that `update_php` can be called directly from the script outside of the sage install workflow, so we can test _that component_ separately. 

BATS tests have been created to test the `update_php` function for all versions from 7.4 - 8.3.

This PR also makes the following minor(ish) adjustments to the sage install script workflow:
- normalizes the generated theme names before the sage install script is called (fixes an issue where tests were failing because themes were created that included slashes in the directories that were created)
- silences the multisite check (sends the output of the check to `/dev/null` so a WP-CLI warning is not thrown if the `MULTISITE` constant does not exist)
- adds a check to see if the Sage theme exists before attempting to activate it