### PR TITLE
Bump PHP version to 8.2 and DB version to 10.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3']
 
     steps:
     - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.1",
     "composer/installers": "^2.2",
     "vlucas/phpdotenv": "^5.5",
     "oscarotero/env": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.0",
     "composer/installers": "^2.2",
     "vlucas/phpdotenv": "^5.5",
     "oscarotero/env": "^2.1",

--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -2,7 +2,7 @@ api_version: 1
 web_docroot: true
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional
-php_version: 8.1
+php_version: 8.2
 database:
   version: 10.4
 build_step: true

--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -4,7 +4,7 @@ web_docroot: true
 enforce_https: transitional
 php_version: 8.2
 database:
-  version: 10.4
+  version: 10.6
 build_step: true
 filemount: /app/uploads
 protected_web_paths:

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -63,6 +63,14 @@ class ComposerScripts
             $composerJson['config']['platform']['php'] = $updatedPlatformPhpVersion;
         }
 
+        // Check to see if the PHP version in the require section of composer.json matches the pantheon.yml PHP version.
+        // If it does not, update it to match the PHP version defined in pantheon.yml.
+        $requirePhpVersion = static::getCurrentRequirePhp($composerJson);
+        if ($requirePhpVersion && false === stripos($requirePhpVersion, $pantheonPhpVersion)) {
+            $io->write("<info>Setting require.php from '$requirePhpVersion' to '>=$pantheonPhpVersion' to conform to pantheon php version.</info>");
+            $composerJson['require']['php'] = ">=$pantheonPhpVersion";
+        }
+
         // add our post-update-cmd hook if it's not already present
         $our_hook = 'WordPressComposerManaged\\ComposerScripts::postUpdate';
         // if does not exist, add as an empty arry
@@ -121,6 +129,18 @@ class ComposerScripts
         $prettyContents = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         $prettyContents = preg_replace('#": \[\s*("[^"]*")\s*\]#m', '": [\1]', $prettyContents);
         return $prettyContents;
+    }
+
+    /**
+     * Get the current require.php value.
+     */
+    private static function getCurrentRequirePhp($composerJson)
+    {
+        $require = $composerJson['require'];
+        if (isset($require['php'])) {
+            return $require['php'];
+        }
+        return null;
     }
 
     /**

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -67,8 +67,11 @@ class ComposerScripts
         // If it does not, update it to match the PHP version defined in pantheon.yml.
         $requirePhpVersion = static::getCurrentRequirePhp($composerJson);
         if ($requirePhpVersion && false === stripos($requirePhpVersion, $pantheonPhpVersion)) {
-            $io->write("<info>Setting require.php from '$requirePhpVersion' to '>=$pantheonPhpVersion' to conform to pantheon php version.</info>");
-            $composerJson['require']['php'] = ">=$pantheonPhpVersion";
+            $strippedRequirePhpVersion = str_replace( '>=', '', $requirePhpVersion);
+            if (version_compare($strippedRequirePhpVersion, '8.1', '<')) {
+                $io->write("<info>Setting require.php from '$requirePhpVersion' to '>=$pantheonPhpVersion' to conform to pantheon php version.</info>");
+                $composerJson['require']['php'] = ">=$pantheonPhpVersion";
+            }
         }
 
         // add our post-update-cmd hook if it's not already present


### PR DESCRIPTION
This pull request updates the PHP version to 8.2 and the DB version to 10.6.

This is good to review, but I am asking in the Roots Bedrock Discord to make sure there aren't good reasons to _not_ upgrade PHP to 8.2 by default. (Sounds like it's a non-issue.)

This PR also bumps the required PHP version in `composer.json` to the version in the `pantheon.yml` file if the `require.php` version is less than the minimum required by Bedrock. This automates the process to bring (and keep) the `require.php` value in the `composer.json` in line with the version running on the platform and the Bedrock required versions.