### PR TITLE
Bring WPCM in line with Bedrock v1.24.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,9 +111,6 @@
       ]
   },
   "scripts": {
-    "post-root-package-install": [
-      "php -r \"copy('.env.example', '.env');\""
-    ],
     "post-install-cmd": "@maybe-create-symlinks",
     "pre-update-cmd": [
       "WordPressComposerManaged\\ComposerScripts::preUpdate"

--- a/config/application.php
+++ b/config/application.php
@@ -10,7 +10,7 @@
 use Roots\WPConfig\Config;
 use function Env\env;
 
-// USE_ENV_ARRAY + CONVERT_* + STRIP_QUOTES
+// USE_ENV_ARRAY + CONVERT_* + STRIP_QUOTES.
 Env\Env::$options = 31;
 
 /**

--- a/config/application.php
+++ b/config/application.php
@@ -10,6 +10,9 @@
 use Roots\WPConfig\Config;
 use function Env\env;
 
+// USE_ENV_ARRAY + CONVERT_* + STRIP_QUOTES
+Env\Env::$options = 31;
+
 /**
  * Directory containing all of the site's files
  *
@@ -32,7 +35,7 @@ $env_files = file_exists( $root_dir . '/.env.local' )
 	? [ '.env', '.env.pantheon', '.env.local' ]
 	: [ '.env', '.env.pantheon' ];
 
-$dotenv = Dotenv\Dotenv::createUnsafeImmutable( $root_dir, $env_files, false );
+$dotenv = Dotenv\Dotenv::createImmutable( $root_dir, $env_files, false );
 if (
 	// Check if a .env file exists.
 	file_exists( $root_dir . '/.env' ) ||


### PR DESCRIPTION
This pull request makes changes to bring the `application.php` and `composer.json` files in line with Bedrock v1.24.x.

Included in the change are updates the usage of Dotenv in the codebase to use the `createImmutable()` method instead of the deprecated `createUnsafeImmutable()` method. It also removes the unnecessary post install script that copies the .env.example file. This improves the security and maintainability of the codebase.