### PR TITLE
Fix fatal error caused by undefined variable

### DIFF
--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -47,6 +47,7 @@ function fix_core_resource_urls( $url ) {
 		return $url;
 	}
 
+	$path = $parsed_url['path'];
 	$core_paths = [ 'wp-includes/', 'wp-admin/', 'wp-content/' ];
 	$path_modified = false;
 
@@ -101,12 +102,12 @@ if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
  * @return string The filtered URL.
  */
 function adjust_main_site_urls( $url ) {
-    // If this is the main site, drop the /wp.
-    if ( is_main_site() ) {
-        $url = str_replace( '/wp/', '/', $url );
-    }
+	// If this is the main site, drop the /wp.
+	if ( is_main_site() ) {
+		$url = str_replace( '/wp/', '/', $url );
+	}
 
-    return $url;
+	return $url;
 }
 add_filter( 'home_url', 'adjust_main_site_urls', 9 );
 add_filter( 'site_url', 'adjust_main_site_urls', 9 );


### PR DESCRIPTION
This pull request fixes a fatal error that occurs when the $path variable is used without being defined. The error was likely caused by the removal of the variable in a previous pull request. The fix ensures that the $path variable is defined before it is used.