### PR TITLE
Update WordPress URL handling and cookie settings

### DIFF
--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -13,6 +13,12 @@
 use Roots\WPConfig\Config;
 use function Env\env;
 
+// Cookie settings.
+defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', $_SERVER['HTTP_HOST'] );
+defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
+defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
+defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );
+
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	if ( ! isset( $_ENV['LANDO'] ) ) {
 		// We can use PANTHEON_SITE_NAME here because it's safe to assume we're on a Pantheon environment if PANTHEON_ENVIRONMENT is set.

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -146,8 +146,6 @@ add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_url
  * @return bool True if the URL is a login or admin URL. False if it's not or is not actually a URL.
  */
 function __is_login_url( string $url ) : bool {
-	$is_login_url = false;
-
 	// Validate that the string passed was actually a URL.
 	if ( ! preg_match( '/^https?:\/\//i', $url ) ) {
 		$url = 'http://' . ltrim( $url, '/' );
@@ -155,20 +153,15 @@ function __is_login_url( string $url ) : bool {
 
 	// Bail if the string is not a valid URL.
 	if ( ! wp_http_validate_url( $url ) ) {
-		return $is_login_url;
+		return false;
 	}
 
-	// Login page?
-	if ( strpos( $url, 'wp-login' ) !== false ) {
-		$is_login_url = true;
+	// Check if the URL is a login or admin page
+	if (strpos($url, 'wp-login') !== false || strpos($url, 'wp-admin') !== false) {
+		return true;
 	}
 
-	// Admin page?
-	if ( strpos( $url, 'wp-admin' ) !== false ) {
-		$is_login_url = true;
-	}
-
-	return $is_login_url;
+	return false
 }
 
 /**

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -116,6 +116,14 @@ function adjust_main_site_urls( string $url ) : string {
 add_filter( 'home_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
 add_filter( 'site_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
 
+/**
+ * Add /wp prefix to all admin and login URLs.
+ * Since /wp is where the core files are installed, this normalizes all non-front-facing urls to use the correct url structure.
+ *
+ * @since 1.1.0
+ * @param string $url The URL to check.
+ * @return string The corrected admin or login URL (or the base url if not an admin or login url).
+ */
 function add_wp_prefix_to_login_and_admin_urls( string $url ) : string {
 	if ( __is_login_url( $url ) ) {
 		if ( strpos( $url, '/wp/' ) === false ) {
@@ -128,6 +136,15 @@ function add_wp_prefix_to_login_and_admin_urls( string $url ) : string {
 add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 
+/**
+ * Check the URL to see if it's either an admin or wp-login URL.
+ *
+ * Validates that the URL is actually a URL before checking.
+ *
+ * @since 1.1.0
+ * @param string $url The URL to check.
+ * @return bool True if the URL is a login or admin URL. False if it's not or is not actually a URL.
+ */
 function __is_login_url( string $url ) : bool {
 	$is_login_url = false;
 
@@ -154,6 +171,13 @@ function __is_login_url( string $url ) : bool {
 	return $is_login_url;
 }
 
+/**
+ * Remove double-slashes (that aren't http/https://) from URLs.
+ *
+ * @since 1.1.0
+ * @param string $url The URL to test.
+ * @return string The normalized URL.
+ */
 function __normalize_wp_url( string $url ) : string {
 	$scheme_end_pos = strpos( $url, '://' );
 

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -113,6 +113,18 @@ function adjust_main_site_urls( string $url ) : string {
 add_filter( 'home_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
 add_filter( 'site_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
 
+function add_wp_prefix_to_login_and_admin_urls( string $url ) : string {
+	if ( __is_login_url( $url ) ) {
+		if ( strpos( $url, '/wp/' ) === false ) {
+			$url = preg_replace( '/(\/wp-(login|admin))/', '/wp/$1', $url );
+		}
+	}
+
+	return __normalize_wp_url( $url );
+}
+add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
+add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
+
 function __is_login_url( string $url ) : bool {
 	$is_login_url = false;
 

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -135,3 +135,20 @@ function __is_login_url( string $url ) : bool {
 
 	return $is_login_url;
 }
+
+function __normalize_wp_url( string $url ) : string {
+	$scheme_end_pos = strpos( $url, '://' );
+
+	// Extract the scheme from the URL.
+	if ( $scheme_end_pos !== false ) {
+		$scheme = substr( $url, 0, $scheme_end_pos + 3 );
+		$remaining_url = substr( $url, $scheme_end_pos + 3 );
+	} else {
+		$scheme = '';
+		$remaining_url = $url;
+	}
+
+	// Normalize the URL to remove any double slashes.
+	$url = str_replace( '//', '/', $remaining_url );
+	return $scheme . $url;
+}

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -104,7 +104,7 @@ if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
  */
 function adjust_main_site_urls( string $url ) : string {
 	// If this is the main site, drop the /wp.
-	if ( is_main_site() ) {
+	if ( is_main_site() && ! __is_login_url( $url ) ) {
 		$url = str_replace( '/wp/', '/', $url );
 	}
 

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -73,7 +73,7 @@ function fix_core_resource_urls( string $url ) : string {
 		$new_url .= '?' . $parsed_url['query'];
 	}
 
-	return $new_url;
+	return __normalize_wp_url( $new_url );
 }
 
 // Only run the filter on non-main sites in a subdirectory multisite network.

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pantheon WordPress Filters
  * Plugin URI:   https://github.com/pantheon-systems/wordpress-composer-managed
  * Description:  Filters for Composer-managed WordPress sites on Pantheon.
- * Version:      1.0.0
+ * Version:      1.1.0
  * Author:       Pantheon Systems
  * Author URI:   https://pantheon.io/
  * License:      MIT License

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -9,6 +9,7 @@
  * License:      MIT License
  */
 
+namespace Pantheon\WordPressComposerManaged\Filters;
 
 /**
  * Update the multisite configuration to use Config::define() instead of define.
@@ -88,7 +89,7 @@ if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
 		'content_url'
 	];
 	foreach ( $filters as $filter ) {
-		add_filter( $filter, 'fix_core_resource_urls', 9 );
+		add_filter( $filter, __NAMESPACE__ . '\\fix_core_resource_urls', 9 );
 	}
 }
 
@@ -109,6 +110,8 @@ function adjust_main_site_urls( $url ) {
 
 	return $url;
 }
+add_filter( 'home_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
+add_filter( 'site_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
 
 function __is_login_url( string $url ) : bool {
 	$is_login_url = false;

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -14,6 +14,7 @@ namespace Pantheon\WordPressComposerManaged\Filters;
 /**
  * Update the multisite configuration to use Config::define() instead of define.
  *
+ * @since 1.0.0
  * @return string
  */
 add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) {
@@ -24,6 +25,7 @@ add_filter( 'pantheon.multisite.config_contents', function ( $config_contents ) 
 /**
  * Update the wp-config filename to use config/application.php.
  *
+ * @since 1.0.0
  * @return string
  */
 add_filter( 'pantheon.multisite.config_filename', function ( $config_filename ) {
@@ -33,6 +35,7 @@ add_filter( 'pantheon.multisite.config_filename', function ( $config_filename ) 
 /**
  * Correct core resource URLs for non-main sites in a subdirectory multisite network.
  *
+ * @since 1.1.0
  * @param string $url The URL to fix.
  * @return string The fixed URL.
  */
@@ -98,8 +101,8 @@ if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
  *
  * is_main_site will return true if the site is not multisite.
  *
+ * @since 1.1.0
  * @param string $url The URL to check.
- *
  * @return string The filtered URL.
  */
 function adjust_main_site_urls( string $url ) : string {

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -36,7 +36,7 @@ add_filter( 'pantheon.multisite.config_filename', function ( $config_filename ) 
  * @param string $url The URL to fix.
  * @return string The fixed URL.
  */
-function fix_core_resource_urls( $url ) {
+function fix_core_resource_urls( string $url ) : string {
 	$main_site_url = trailingslashit( network_site_url( '/' ) );
 	$current_site_path = trailingslashit( get_blog_details()->path );
 
@@ -102,7 +102,7 @@ if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
  *
  * @return string The filtered URL.
  */
-function adjust_main_site_urls( $url ) {
+function adjust_main_site_urls( string $url ) : string {
 	// If this is the main site, drop the /wp.
 	if ( is_main_site() ) {
 		$url = str_replace( '/wp/', '/', $url );

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -125,13 +125,13 @@ add_filter( 'site_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
  * @return string The corrected admin or login URL (or the base url if not an admin or login url).
  */
 function add_wp_prefix_to_login_and_admin_urls( string $url ) : string {
-	if ( __is_login_url( $url ) ) {
-		if ( strpos( $url, '/wp/' ) === false ) {
-			$url = __normalize_wp_url( preg_replace( '/(\/wp-(login|admin))/', '/wp/$1', $url ) );
-		}
+	if (  ! __is_login_url( $url ) ) {
+		return $url;
 	}
-
-	return $url;
+	if ( strpos( $url, '/wp/' ) !== false ) {
+		return $url;
+	}
+	return __normalize_wp_url( preg_replace( '/(\/wp-(login|admin))/', '/wp/$1', $url ) );
 }
 add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -171,19 +171,16 @@ function __is_login_url( string $url ) : bool {
  * @param string $url The URL to test.
  * @return string The normalized URL.
  */
-function __normalize_wp_url( string $url ) : string {
-	$scheme_end_pos = strpos( $url, '://' );
+function __normalize_wp_url( string $url ): string {
+    $scheme = parse_url( $url, PHP_URL_SCHEME );
+    $scheme_with_separator = $scheme ? $scheme . '://' : '';
 
-	// Extract the scheme from the URL.
-	if ( $scheme_end_pos !== false ) {
-		$scheme = substr( $url, 0, $scheme_end_pos + 3 );
-		$remaining_url = substr( $url, $scheme_end_pos + 3 );
-	} else {
-		$scheme = '';
-		$remaining_url = $url;
-	}
+    // Remove the scheme from the URL if it exists.
+    $remaining_url = $scheme ? substr( $url, strlen($scheme_with_separator ) ) : $url;
 
-	// Normalize the URL to remove any double slashes.
-	$url = str_replace( '//', '/', $remaining_url );
-	return $scheme . $url;
+    // Normalize the remaining URL to remove any double slashes.
+    $normalized_url = str_replace( '//', '/', $remaining_url );
+
+    // Reconstruct and return the full normalized URL.
+    return $scheme_with_separator . $normalized_url;
 }

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -109,5 +109,29 @@ function adjust_main_site_urls( $url ) {
 
 	return $url;
 }
-add_filter( 'home_url', 'adjust_main_site_urls', 9 );
-add_filter( 'site_url', 'adjust_main_site_urls', 9 );
+
+function __is_login_url( string $url ) : bool {
+	$is_login_url = false;
+
+	// Validate that the string passed was actually a URL.
+	if ( ! preg_match( '/^https?:\/\//i', $url ) ) {
+		$url = 'http://' . ltrim( $url, '/' );
+	}
+
+	// Bail if the string is not a valid URL.
+	if ( ! wp_http_validate_url( $url ) ) {
+		return $is_login_url;
+	}
+
+	// Login page?
+	if ( strpos( $url, 'wp-login' ) !== false ) {
+		$is_login_url = true;
+	}
+
+	// Admin page?
+	if ( strpos( $url, 'wp-admin' ) !== false ) {
+		$is_login_url = true;
+	}
+
+	return $is_login_url;
+}

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -119,11 +119,11 @@ add_filter( 'site_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
 function add_wp_prefix_to_login_and_admin_urls( string $url ) : string {
 	if ( __is_login_url( $url ) ) {
 		if ( strpos( $url, '/wp/' ) === false ) {
-			$url = preg_replace( '/(\/wp-(login|admin))/', '/wp/$1', $url );
+			$url = __normalize_wp_url( preg_replace( '/(\/wp-(login|admin))/', '/wp/$1', $url ) );
 		}
 	}
 
-	return __normalize_wp_url( $url );
+	return $url;
 }
 add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );


### PR DESCRIPTION
This pull request includes several changes to improve the handling of URLs in WordPress particularly for multisite. 

Included in the update are helper functions to check and strip double-slashes from URLs, namespacing, enforcing strict types, and a version bump for the filters mu-plugin. 

Importantly, this PR enforces the `/wp` prefix to admin and login URLs which prevents an infinite login redirect loop. 

The PR also adds a cookie domain fix for multisite logins which is a common issue for subdomain multisite.