### PR TITLE
[CMSP-1459] Fixes URL normalization process

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
+/package.json export-ignore

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -16,9 +16,9 @@ test("WP REST API is accessible", async ({ request }) => {
 });
 
 test("Hello World post is accessible", async ({ page }) => {
-  await page.goto(`${siteUrl}/hello-world`);
-  const h2Element = await page.locator('h2');
-  await expect(h2Element).toHaveText(exampleArticle);
+  await page.goto(`${siteUrl}/hello-world/'`);
+  await expect(page).toHaveTitle(`${exampleArticle} - ${siteTitle}`);
+  await expect(page).toHaveText('Welcome to WordPress');
 });
 
 test("validate core resource URLs", async ({ request }) => {

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -17,7 +17,9 @@ test("WP REST API is accessible", async ({ request }) => {
 
 test("Hello World post is accessible", async ({ page }) => {
   await page.goto(`${siteUrl}/hello-world`);
-  await expect(page).toHaveTitle(`${exampleArticle} – ${siteTitle}`);
+  const h2Element = await page.locator('h2');
+  await expect(h2Element).toHaveText(exampleArticle);
+});
 });
 
 test("graphql is able to access hello world post", async ({ request }) => {

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -18,7 +18,9 @@ test("WP REST API is accessible", async ({ request }) => {
 test("Hello World post is accessible", async ({ page }) => {
   await page.goto(`${siteUrl}/hello-world/'`);
   await expect(page).toHaveTitle(`${exampleArticle} – ${siteTitle}`);
-  await expect(page).toHaveText('Welcome to WordPress');
+  // Locate the element containing the desired text
+  const welcomeText = page.locator('text=Welcome to WordPress');
+  await expect(welcomeText).toHaveText('Welcome to WordPress');
 });
 
 test("validate core resource URLs", async ({ request }) => {

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -20,7 +20,7 @@ test("Hello World post is accessible", async ({ page }) => {
   await expect(page).toHaveTitle(`${exampleArticle} – ${siteTitle}`);
   // Locate the element containing the desired text
   const welcomeText = page.locator('text=Welcome to WordPress');
-  await expect(welcomeText).toHaveText('Welcome to WordPress');
+  await expect(welcomeText).toContainText('Welcome to WordPress');
 });
 
 test("validate core resource URLs", async ({ request }) => {

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -22,8 +22,6 @@ test("Hello World post is accessible", async ({ page }) => {
 });
 
 test("validate core resource URLs", async ({ request }) => {
-  await page.goto(siteUrl);
-
   const coreResources = [
     'wp-includes/js/dist/interactivity.min.js',
     'wp-includes/css/dist/editor.min.css',

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -21,7 +21,7 @@ test("Hello World post is accessible", async ({ page }) => {
   await expect(h2Element).toHaveText(exampleArticle);
 });
 
-test("validate core resource URLs", async ({ page }) => {
+test("validate core resource URLs", async ({ request }) => {
   await page.goto(siteUrl);
 
   const coreResources = [
@@ -31,8 +31,8 @@ test("validate core resource URLs", async ({ page }) => {
 
   for ( const resource of coreResources ) {
     const resourceUrl = `${siteUrl}/wp/${resource}`;
-    const element = await page.locator(`link[href="${resourceUrl}"], script[src="${resourceUrl}"]`);
-    await expect(element).toBeVisible();
+    const response = await request.get(resourceUrl);
+    await expect(response).toBeTruthy();
   }
 });
 

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -31,7 +31,7 @@ test("validate core resource URLs", async ({ page }) => {
 
   for ( const resource of coreResources ) {
     const resourceUrl = `${siteUrl}/wp/${resource}`;
-    const element = await page.locator(`link[href="${resourceUrl}], script[src="${resourceUrl}"]`);
+    const element = await page.locator(`link[href="${resourceUrl}"], script[src="${resourceUrl}"]`);
     await expect(element).toBeVisible();
   }
 });

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+const exampleArticle = "Hello world!";
+const siteTitle = "WPCM Playwright Tests";
+const siteUrl = process.env.SITE_URL || "https://dev-wpcm-playwright-tests.pantheonsite.io";
+
+test("homepage loads and contains example content", async ({ page }) => {
+  await page.goto(siteUrl);
+  await expect(page).toHaveTitle(siteTitle);
+  await expect(page.getByText(exampleArticle)).toHaveText(exampleArticle);
+});
+
+test("WP REST API is accessible", async ({ request }) => {
+  const apiRoot = await request.get(`${siteUrl}/wp-json`);
+  expect(apiRoot.ok()).toBeTruthy();
+});
+
+test("Hello World post is accessible", async ({ page }) => {
+  await page.goto(`${siteUrl}/hello-world`);
+  await expect(page).toHaveTitle(`${exampleArticle} – ${siteTitle}`);
+});
+
+test("graphql is able to access hello world post", async ({ request }) => {
+  const query = `
+    query {
+      posts(where: { search: "${exampleArticle}" }) {
+        edges {
+          node {
+            title
+          }
+        }
+      }
+    }
+  `;
+
+  const response = await request.post(`${siteUrl}/wp/graphql`, {
+    data: {
+      query: query
+    },
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+
+  const responseBody = await response.json();
+
+  expect(responseBody.data.posts.edges.length).toBeGreaterThan(0);
+  expect(responseBody.data.posts.edges[0].node.title).toBe(exampleArticle);
+});

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -20,6 +20,20 @@ test("Hello World post is accessible", async ({ page }) => {
   const h2Element = await page.locator('h2');
   await expect(h2Element).toHaveText(exampleArticle);
 });
+
+test("validate core resource URLs", async ({ page }) => {
+  await page.goto(siteUrl);
+
+  const coreResources = [
+    'wp-includes/js/dist/interactivity.min.js',
+    'wp-includes/css/dist/editor.min.css',
+  ];
+
+  for ( const resource of coreResources ) {
+    const resourceUrl = `${siteUrl}/wp/${resource}`;
+    const element = await page.locator(`link[href="${resourceUrl}], script[src="${resourceUrl}"]`);
+    await expect(element).toBeVisible();
+  }
 });
 
 test("graphql is able to access hello world post", async ({ request }) => {

--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -17,7 +17,7 @@ test("WP REST API is accessible", async ({ request }) => {
 
 test("Hello World post is accessible", async ({ page }) => {
   await page.goto(`${siteUrl}/hello-world/'`);
-  await expect(page).toHaveTitle(`${exampleArticle} - ${siteTitle}`);
+  await expect(page).toHaveTitle(`${exampleArticle} – ${siteTitle}`);
   await expect(page).toHaveText('Welcome to WordPress');
 });
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,7 +62,7 @@ jobs:
           git config --global user.name "Pantheon WPCM Bot 🤖"
           PR_NUMBER=$(echo ${{ github.event.pull_request.number }})
           echo "Pull Request Number: ${PR_NUMBER}"
-          COMMIT_MSG=$(gh pr view ${PR_NUMBER} --json commits --jq '.commits[-1].messageHeadline')
+          COMMIT_MSG=$(gh pr view ${PR_NUMBER} --json commits --jq '.commits[-1] | "\(.messageHeadline) \(.messageBody)"')
           echo "Commit Message: ${COMMIT_MSG}"
           terminus local:clone wpcm-playwright-tests
           cd ~/pantheon-local-copies/wpcm-playwright-tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -77,7 +77,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git config --global user.email "cms-platform+sage-testing@pantheon.io"
-          git config --global user.name "Pantheon WPCM Bot 🤖"
+          git config --global user.name "Pantheon WPCM Bot"
           PR_NUMBER=$(echo ${{ github.event.pull_request.number }})
           echo "Pull Request Number: ${PR_NUMBER}"
           COMMIT_MSG=$(gh pr view ${PR_NUMBER} --json commits --jq '.commits[-1] | "\(.messageHeadline) \(.messageBody)"')

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,6 +55,8 @@ jobs:
           fi
 
       - name: Clone the site and copy PR updates
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --global user.email "cms-platform+sage-testing@pantheon.io"
           git config --global user.name "Pantheon WPCM Bot 🤖"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up cache for dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            ./vendor
+            ~/.npm
+            ./node_modules
+          key: ${{ runner.os }}-deps-${{ hashFiles( '**/composer.lock', '**/package-lock.json' ) }}
+          restore-keys: ${{ runner.os }}-deps-
+
+
       - name: Install Composer dependencies
         run: composer update --no-progress --prefer-dist --optimize-autoloader
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -60,7 +60,10 @@ jobs:
         run: |
           git config --global user.email "cms-platform+sage-testing@pantheon.io"
           git config --global user.name "Pantheon WPCM Bot 🤖"
-          COMMIT_MSG=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits[-1].commit.message')
+          PR_NUMBER=$(echo ${{ github.event.pull_request.number }})
+          echo "Pull Request Number: ${PR_NUMBER}"
+          COMMIT_MSG=$(gh pr view ${PR_NUMBER} --json commits --jq '.commits[-1].commit.message')
+          echo "Commit Message: ${COMMIT_MSG}"
           terminus local:clone wpcm-playwright-tests
           cd ~/pantheon-local-copies/wpcm-playwright-tests
           rsync -a --exclude='.git' ${{ github.workspace }}/ .

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,7 +62,7 @@ jobs:
           git config --global user.name "Pantheon WPCM Bot 🤖"
           PR_NUMBER=$(echo ${{ github.event.pull_request.number }})
           echo "Pull Request Number: ${PR_NUMBER}"
-          COMMIT_MSG=$(gh pr view ${PR_NUMBER} --json commits --jq '.commits[-1].commit.message')
+          COMMIT_MSG=$(gh pr view ${PR_NUMBER} --json commits --jq '.commits[-1].messageHeadline')
           echo "Commit Message: ${COMMIT_MSG}"
           terminus local:clone wpcm-playwright-tests
           cd ~/pantheon-local-copies/wpcm-playwright-tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
         run: composer update --no-progress --prefer-dist --optimize-autoloader
 
       - name: Install NPM dependencies
-        run: npm ci
+        run: npm install
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,11 +52,13 @@ jobs:
             terminus site:create wpcm-playwright-tests 'WordPress (Composer Managed) Playwright Test Site' 'WordPress (Composer Managed)' --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
           fi
 
-      - name: Clone the site and pull down updates
+      - name: Clone the site and copy PR updates
         run: |
+          git config --global user.email "cms-platform+sage-testing@pantheon.io"
+          git config --global user.name "Pantheon WPCM Bot 🤖"
           terminus local:clone wpcm-playwright-tests
           cd ~/pantheon-local-copies/wpcm-playwright-tests
-          rsync -a --exclude='.git' ${{ github.workspace }} .
+          rsync -a --exclude='.git' ${{ github.workspace }}/ .
           git add -A
           git commit -m "Update to latest"
           git push origin master

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate lock files
+        run: |
+          composer update --lock
+          npm install --package-lock-only
+
       - name: Set up cache for dependencies
         uses: actions/cache@v4
         with:
@@ -33,7 +38,7 @@ jobs:
         run: composer update --no-progress --prefer-dist --optimize-autoloader
 
       - name: Install NPM dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,7 @@ jobs:
           if terminus site:info wpcm-playwright-tests; then
             echo "Test site already exists, skipping site creation."
             # If the site exists already, we should switch it to git mode.
-            terminus connection:set wpcm-playwright-tests.dev git
+            terminus connection:set wpcm-playwright-tests.dev git -y
           else
             terminus site:create wpcm-playwright-tests 'WordPress (Composer Managed) Playwright Test Site' 'WordPress (Composer Managed)' --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
           fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -61,8 +61,9 @@ jobs:
           terminus local:clone wpcm-playwright-tests
           cd ~/pantheon-local-copies/wpcm-playwright-tests
           rsync -a --exclude='.git' ${{ github.workspace }}/ .
+          COMMIT_MSG=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits[-1].commit.message')
           git add -A
-          git commit -m "Update to latest"
+          git commit -m "Update to latest commit: ${COMMIT_MSG}"
           git push origin master
 
       - name: Status Check

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Install WP GraphQL
         run: |
+          terminus workflow:wait wpcm-playwright-tests.dev
           terminus connection:set wpcm-playwright-tests.dev sftp
           terminus wp wpcm-playwright-tests.dev -- plugin install --activate wp-graphql
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,25 +19,26 @@ jobs:
 
       - name: Generate lock files
         run: |
-          composer update --lock
           npm install --package-lock-only
 
       - name: Set up cache for dependencies
         uses: actions/cache@v4
+        id: cache
         with:
           path: |
             ~/.composer/cache
             ./vendor
             ~/.npm
             ./node_modules
-          key: ${{ runner.os }}-deps-${{ hashFiles( '**/composer.lock', '**/package-lock.json' ) }}
+          key: ${{ runner.os }}-deps-${{ hashFiles( '**/composer.json', '**/package-lock.json' ) }}
           restore-keys: ${{ runner.os }}-deps-
 
-
       - name: Install Composer dependencies
+        if: steps.cache.outputs.cache-hit != true
         run: composer update --no-progress --prefer-dist --optimize-autoloader
 
       - name: Install NPM dependencies
+        if: steps.cache.outputs.cache-hit != true
         run: npm ci
 
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -60,10 +60,10 @@ jobs:
         run: |
           git config --global user.email "cms-platform+sage-testing@pantheon.io"
           git config --global user.name "Pantheon WPCM Bot 🤖"
+          COMMIT_MSG=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits[-1].commit.message')
           terminus local:clone wpcm-playwright-tests
           cd ~/pantheon-local-copies/wpcm-playwright-tests
           rsync -a --exclude='.git' ${{ github.workspace }}/ .
-          COMMIT_MSG=$(gh pr view ${{ github.event.pull_request.number }} --json commits --jq '.commits[-1].commit.message')
           git add -A
           git commit -m "Update to latest commit: ${COMMIT_MSG}"
           git push origin master

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -46,7 +46,11 @@ jobs:
 
       - name: Create Site
         run: |
-          terminus site:create wpcm-playwright-tests 'WordPress (Composer Managed) Playwright Test Site' 'WordPress (Composer Managed)' --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
+          if terminus site:info wpcm-playwright-tests; then
+            echo "Test site already exists, skipping site creation."
+          else
+            terminus site:create wpcm-playwright-tests 'WordPress (Composer Managed) Playwright Test Site' 'WordPress (Composer Managed)' --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
+          fi
 
       - name: Clone the site and pull down updates
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -67,7 +67,11 @@ jobs:
         run: terminus wp wpcm-playwright-tests.dev -- cli info
 
       - name: Install WordPress
-        run: terminus wp wpcm-playwright-tests.dev -- core install --title='WPCM Playwright Tests' --admin_user=wpcm --admin_email=test@dev.null
+        run: |
+          terminus wp wpcm-playwright-tests.dev -- core install --title='WPCM Playwright Tests' --admin_user=wpcm --admin_email=test@dev.null
+          terminus wp wpcm-playwright-tests.dev -- option update permalink_structure '/%postname%/'
+          terminus wp wpcm-playwright-tests.dev -- rewrite flush
+          terminus wp wpcm-playwright-tests.dev -- cache flush
 
       - name: Install WP GraphQL
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -54,7 +54,7 @@ jobs:
             terminus site:create wpcm-playwright-tests 'WordPress (Composer Managed) Playwright Test Site' 'WordPress (Composer Managed)' --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
           fi
 
-      - name: Clone the site and copy PR updates
+      - name: Clone the site locally and copy PR updates
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -68,8 +68,8 @@ jobs:
           cd ~/pantheon-local-copies/wpcm-playwright-tests
           rsync -a --exclude='.git' ${{ github.workspace }}/ .
           git add -A
-          git commit -m "Update to latest commit: ${COMMIT_MSG}"
-          git push origin master
+          git commit -m "Update to latest commit: ${COMMIT_MSG}" || true
+          git push origin master || true
 
       - name: Status Check
         run: terminus wp wpcm-playwright-tests.dev -- cli info

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,76 @@
+name: WordPress (Composer Managed) Playwright Tests
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+    contents: write
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Composer dependencies
+        run: composer update --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Install SSH keys
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Get latest Terminus release
+        uses: pantheon-systems/terminus-github-actions@v1
+        with:
+          pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
+      - name: Validate Pantheon Host Key
+        run: |
+          echo "Host *.drush.in HostKeyAlgorithms +ssh-rsa" >> ~/.ssh/config
+          echo "Host *.drush.in PubkeyAcceptedKeyTypes +ssh-rsa" >> ~/.ssh/config
+          echo "StrictHostKeyChecking no" >> ~/.ssh/config
+      - name: Log into Terminus
+        run: |
+          terminus auth:login --machine-token=${{ secrets.TERMINUS_TOKEN }}
+
+      - name: Create Site
+        run: |
+          terminus site:create wpcm-playwright-tests 'WordPress (Composer Managed) Playwright Test Site' 'WordPress (Composer Managed)' --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
+
+      - name: Clone the site and pull down updates
+        run: |
+          terminus local:clone wpcm-playwright-tests
+          cd ~/pantheon-local-copies/wpcm-playwright-tests
+          rsync -a --exclude='.git' ${{ github.workspace }} .
+          git add -A
+          git commit -m "Update to latest"
+          git push origin master
+
+      - name: Status Check
+        run: terminus wp wpcm-playwright-tests.dev -- cli info
+
+      - name: Install WordPress
+        run: terminus wp wpcm-playwright-tests.dev -- core install --title='WPCM Playwright Tests' --admin_user=wpcm --admin_email=test@dev.null
+
+      - name: Install WP GraphQL
+        run: |
+          terminus connection:set wpcm-playwright-tests.dev sftp
+          terminus wp wpcm-playwright-tests.dev -- plugin install --activate wp-graphql
+
+      - name: Run Playwright Tests
+        run: npm run test .github/tests/wpcm.spec.ts
+
+      - name: Delete Site
+        if: success()
+        run: terminus site:delete wpcm-playwright-tests -y

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           if terminus site:info wpcm-playwright-tests; then
             echo "Test site already exists, skipping site creation."
+            # If the site exists already, we should switch it to git mode.
+            terminus connection:set wpcm-playwright-tests.dev git
           else
             terminus site:create wpcm-playwright-tests 'WordPress (Composer Managed) Playwright Test Site' 'WordPress (Composer Managed)' --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
           fi

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@pantheon-systems/wordpress-composer-managed",
+  "version": "1.31.0",
+  "description": "Automated testing for WordPress (Composer Managed).",
+  "scripts": {
+    "test": "playwright test --trace on",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.28.0"
+  }
+}

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -55,9 +55,9 @@ class ComposerScripts
         // is the same as the Pantheon PHP version (which is only major.minor).
         // If they do not match, force an update to the platform PHP version. If they
         // have the same major.minor version, then
-        $platformPhpVersion = static::getCurrentPlatformPhp($event);
-        $pantheonPhpVersion = static::getPantheonPhpVersion($event);
-        $updatedPlatformPhpVersion = static::bestPhpPatchVersion($pantheonPhpVersion);
+        $platformPhpVersion = static::getCurrentPlatformPhp($event) ?? '';
+        $pantheonPhpVersion = static::getPantheonPhpVersion($event) ?? '';
+        $updatedPlatformPhpVersion = static::bestPhpPatchVersion($pantheonPhpVersion) ?? '';
         if ((substr($platformPhpVersion, 0, strlen($pantheonPhpVersion)) != $pantheonPhpVersion) && !empty($updatedPlatformPhpVersion)) {
             $io->write("<info>Setting platform.php from '$platformPhpVersion' to '$updatedPlatformPhpVersion' to conform to pantheon php version.</info>");
             $composerJson['config']['platform']['php'] = $updatedPlatformPhpVersion;

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -172,6 +172,16 @@ function __is_login_url( string $url ) : bool {
  * @return string The normalized URL.
  */
 function __normalize_wp_url( string $url ): string {
+	$scheme = parse_url( $url );
+
+	// Normalize the URL to remove any double slashes.
+	if ( isset( $parts['path'] ) ) {
+		$parts['path'] = preg_replace( '#/+#', '/', $parts['path'] );
+	}
+
+	// Rebuild and return the full normalized URL.
+	return __rebuild_url_from_parts( $parts );
+}
 
 /**
  * Rebuild parsed URL from parts.

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -137,6 +137,27 @@ add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_url
 add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 
 /**
+ * Ensure the /wp prefix is retained in the WPGraphQL endpoint.
+ *
+ * @since 1.1.0
+ * @param null|string $endpoint The GraphQL endpoint.
+ * @return null|string The filtered GraphQL endpoint.
+ */
+add_filter( 'graphql_endpoint', function( $endpoint ) {
+    $desired_endpoint = '/wp/graphql';
+
+    if ( ! $endpoint ) {
+        return $desired_endpoint;
+    }
+
+    if ( $endpoint && strpos( $endpoint, '/wp' ) === false ) {
+        $endpoint = "/wp/$endpoint";
+    }
+
+    return $endpoint;
+}, 9 );
+
+/**
  * Check the URL to see if it's either an admin or wp-login URL.
  *
  * Validates that the URL is actually a URL before checking.
@@ -157,11 +178,11 @@ function __is_login_url( string $url ) : bool {
 	}
 
 	// Check if the URL is a login or admin page
-	if (strpos($url, 'wp-login') !== false || strpos($url, 'wp-admin') !== false) {
+	if ( strpos( $url, 'wp-login' ) !== false || strpos($url, 'wp-admin' ) !== false) {
 		return true;
 	}
 
-	return false
+	return false;
 }
 
 /**
@@ -172,7 +193,7 @@ function __is_login_url( string $url ) : bool {
  * @return string The normalized URL.
  */
 function __normalize_wp_url( string $url ): string {
-	$scheme = parse_url( $url );
+	$parts = parse_url( $url );
 
 	// Normalize the URL to remove any double slashes.
 	if ( isset( $parts['path'] ) ) {
@@ -192,9 +213,9 @@ function __normalize_wp_url( string $url ): string {
  */
 function __rebuild_url_from_parts( array $parts ) : string {
 	return trailingslashit(
-		isset( $parts['scheme'] ) ? "{$parts['scheme']}:" : '' .
-		isset( $parts['path'] ) ? untrailingslashit( "{$parts['path']}" ) : '' .
-		isset( $parts['query'] ) ? str_replace( '/', '', "?{$parts['query']}" ) : '' .
-		isset( $parts['fragment'] ) ? str_replace( '/', '', "#{$parts['fragment']}" ) : ''
+		( isset( $parts['scheme'] ) ? "{$parts['scheme']}:" : '' ) .
+		( isset( $parts['path'] ) ? untrailingslashit( "{$parts['path']}" ) : '' ) .
+		( isset( $parts['query'] ) ? str_replace( '/', '', "?{$parts['query']}" ) : '' ) .
+		( isset( $parts['fragment'] ) ? str_replace( '/', '', "#{$parts['fragment']}" ) : '' )
 	);
 }

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -143,7 +143,7 @@ add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_url
  * @param null|string $endpoint The GraphQL endpoint.
  * @return null|string The filtered GraphQL endpoint.
  */
-add_filter( 'graphql_endpoint', function( $endpoint ) {
+function ensure_graphql_url_prefix( $endpoint ) : null|string {
     $desired_endpoint = '/wp/graphql';
 
     if ( ! $endpoint ) {
@@ -155,7 +155,8 @@ add_filter( 'graphql_endpoint', function( $endpoint ) {
     }
 
     return $endpoint;
-}, 9 );
+}
+add_filter( 'graphql_endpoint', __NAMESPACE__ . '\\ensure_graphql_url_prefix',  9 );
 
 /**
  * Check the URL to see if it's either an admin or wp-login URL.

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -172,15 +172,19 @@ function __is_login_url( string $url ) : bool {
  * @return string The normalized URL.
  */
 function __normalize_wp_url( string $url ): string {
-    $scheme = parse_url( $url, PHP_URL_SCHEME );
-    $scheme_with_separator = $scheme ? $scheme . '://' : '';
 
-    // Remove the scheme from the URL if it exists.
-    $remaining_url = $scheme ? substr( $url, strlen($scheme_with_separator ) ) : $url;
-
-    // Normalize the remaining URL to remove any double slashes.
-    $normalized_url = str_replace( '//', '/', $remaining_url );
-
-    // Reconstruct and return the full normalized URL.
-    return $scheme_with_separator . $normalized_url;
+/**
+ * Rebuild parsed URL from parts.
+ *
+ * @since 1.1.0
+ * @param array $parts URL parts from parse_url.
+ * @return string Re-parsed URL.
+ */
+function __rebuild_url_from_parts( array $parts ) : string {
+	return trailingslashit(
+		isset( $parts['scheme'] ) ? "{$parts['scheme']}:" : '' .
+		isset( $parts['path'] ) ? untrailingslashit( "{$parts['path']}" ) : '' .
+		isset( $parts['query'] ) ? str_replace( '/', '', "?{$parts['query']}" ) : '' .
+		isset( $parts['fragment'] ) ? str_replace( '/', '', "#{$parts['fragment']}" ) : ''
+	);
 }

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -125,6 +125,15 @@ add_action( 'graphql_init', __NAMESPACE__ . '\\prepopulate_graphql_endpoint_url'
  * @return string The filtered URL.
  */
 function adjust_main_site_urls( string $url ) : string {
+	if ( doing_action( 'graphql_init' ) ) {
+		return $url;
+	}
+
+	// Explicit handling for /wp/graphql
+	if ( strpos( $url, '/graphql' ) !== false ) {
+		return $url;
+	}
+
 	// If this is the main site, drop the /wp.
 	if ( is_main_site() && ! __is_login_url( $url ) ) {
 		$url = str_replace( '/wp/', '/', $url );
@@ -191,6 +200,7 @@ function __is_login_url( string $url ) : bool {
  * @return string The normalized URL.
  */
 function __normalize_wp_url( string $url ): string {
+	// Parse the URL into components.
 	$parts = parse_url( $url );
 
 	// Normalize the URL to remove any double slashes.

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -215,6 +215,7 @@ function __normalize_wp_url( string $url ): string {
 function __rebuild_url_from_parts( array $parts ) : string {
 	return trailingslashit(
 		( isset( $parts['scheme'] ) ? "{$parts['scheme']}:" : '' ) .
+        ( isset( $parts['host'] ) ? "{$parts['host']}" : '' ) .
 		( isset( $parts['path'] ) ? untrailingslashit( "{$parts['path']}" ) : '' ) .
 		( isset( $parts['query'] ) ? str_replace( '/', '', "?{$parts['query']}" ) : '' ) .
 		( isset( $parts['fragment'] ) ? str_replace( '/', '', "#{$parts['fragment']}" ) : '' )

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -97,6 +97,25 @@ if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
 }
 
 /**
+ * Prepopulate GraphQL endpoint URL with default value if unset.
+ * This will ensure that the URL is not changed from /wp/graphql to /graphql by our other filtering unless that's what the user wants.
+ *
+ * @since 1.1.0
+ */
+function prepopulate_graphql_endpoint_url() {
+	$options = get_option( 'graphql_general_settings' );
+	$site_path = site_url();
+
+	if ( ! $options ) {
+		$endpoint = ( ! empty( $site_path ) || strpos( $site_path, 'wp' ) !== false ) ? 'graphql' : 'wp/graphql';
+		$options = [];
+		$options['graphql_endpoint'] = $endpoint;
+		update_option( 'graphql_general_settings', $options );
+	}
+}
+add_action( 'graphql_init', __NAMESPACE__ . '\\prepopulate_graphql_endpoint_url' );
+
+/**
  * Drop the /wp, if it exists, from URLs on the main site (single site or multisite).
  *
  * is_main_site will return true if the site is not multisite.
@@ -135,22 +154,6 @@ function add_wp_prefix_to_login_and_admin_urls( string $url ) : string {
 }
 add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
-
-/**
- * Prepopulate GraphQL endpoint URL with default value if unset.
- * This will ensure that the URL is not changed from /wp/graphql to /graphql by our other filtering unless that's what the user wants.
- *
- * @since 1.1.0
- */
-function prepopulate_graphql_endpoint_url() {
-    $options = get_option( 'graphql_general_settings' );
-    if ( ! $options ) {
-        $options = [];
-        $options['graphql_endpoint'] = '/wp/graphql';
-        update_option( 'graphql_general_settings', $options );
-    }
-}
-add_action( 'graphql_init', __NAMESPACE__ . '\\prepopulate_graphql_endpoint_url' );
 
 /**
  * Check the URL to see if it's either an admin or wp-login URL.

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -137,26 +137,20 @@ add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_url
 add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 
 /**
- * Ensure the /wp prefix is retained in the WPGraphQL endpoint.
+ * Prepopulate GraphQL endpoint URL with default value if unset.
+ * This will ensure that the URL is not changed from /wp/graphql to /graphql by our other filtering unless that's what the user wants.
  *
  * @since 1.1.0
- * @param null|string $endpoint The GraphQL endpoint.
- * @return null|string The filtered GraphQL endpoint.
  */
-function ensure_graphql_url_prefix( $endpoint ) : null|string {
-    $desired_endpoint = '/wp/graphql';
-
-    if ( ! $endpoint ) {
-        return $desired_endpoint;
+function prepopulate_graphql_endpoint_url() {
+    $options = get_option( 'graphql_general_settings' );
+    if ( ! $options ) {
+        $options = [];
+        $options['graphql_endpoint'] = '/wp/graphql';
+        update_option( 'graphql_general_settings', $options );
     }
-
-    if ( $endpoint && strpos( $endpoint, '/wp' ) === false ) {
-        $endpoint = "/wp/$endpoint";
-    }
-
-    return $endpoint;
 }
-add_filter( 'graphql_endpoint', __NAMESPACE__ . '\\ensure_graphql_url_prefix',  9 );
+add_action( 'graphql_init', __NAMESPACE__ . '\\prepopulate_graphql_endpoint_url' );
 
 /**
  * Check the URL to see if it's either an admin or wp-login URL.

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -104,14 +104,17 @@ if ( is_multisite() && ! is_subdomain_install() && ! is_main_site() ) {
  */
 function prepopulate_graphql_endpoint_url() {
 	$options = get_option( 'graphql_general_settings' );
-	$site_path = site_url();
 
-	if ( ! $options ) {
-		$endpoint = ( ! empty( $site_path ) || strpos( $site_path, 'wp' ) !== false ) ? 'graphql' : 'wp/graphql';
-		$options = [];
-		$options['graphql_endpoint'] = $endpoint;
-		update_option( 'graphql_general_settings', $options );
-	}
+    // Bail early if options have already been set.
+    if ( $options ) {
+        return;
+    }
+
+    $options = [];
+	$site_path = site_url();
+    $endpoint = ( ! empty( $site_path ) || strpos( $site_path, 'wp' ) !== false ) ? 'graphql' : 'wp/graphql';
+    $options['graphql_endpoint'] = $endpoint;
+    update_option( 'graphql_general_settings', $options );
 }
 add_action( 'graphql_init', __NAMESPACE__ . '\\prepopulate_graphql_endpoint_url' );
 


### PR DESCRIPTION
This pull request 

* adds a new helper function that re-parses and normalizes a URL from its parts
* updates the existing WP URL normalization function to use the new helper function.
* pre-sets the endpoint option so the updated URL handling does not break existing sites expecting the endpoint to be at `/wp/graphql` while still allowing that option to be set via the plugin options.
* adds Playwright tests (adapted from Canaries) that are run on all PRs

This resolves an issue where URLs were being interpreted incorrectly. Most notably, WP core library urls (e.g. to files like `/wp-includes/js/dist/interactivity.min.js`) were being rendered as `https://dev-cxr-wpcm-canary-test.pantheonsite.io/wp-includes/js/dist/interactivity.min.js/?ver=6.5.5`.

Additionally, this should resolve the issues with URL structure causing the canary tests to fail.