### PR TITLE
[BUGS-8491] only set `DISABLE_WP_CRON` value once

### DIFF
--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -66,8 +66,19 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 				putenv( 'WP_SITEURL=' . $homeurl . '/wp' );
 			}
 		}
+
+        /**
+         * Disable wp-cron.php from running on every page load and rely on Pantheon to run cron via wp-cli.
+         * We make an explicit exception here for multisite because there are cases where multisite does not work properly when WP_Cron is disabled.
+         * We only define DISABLE_WP_CRON if it's not already defined, which means you can override it in the application.php (though we don't recommend it).
+         */
+        $network = isset( $_ENV["FRAMEWORK"] ) && $_ENV["FRAMEWORK"] === 'wordpress_network';
+        if ( ! defined( 'DISABLE_WP_CRON' ) && ! env( 'DISABLE_WP_CRON' ) && $network === false ) {
+            Config::define( 'DISABLE_WP_CRON', true );
+        }
 	}
 
+	// Define PANTHEON_HOSTNAME.
 	if ( ! defined( 'PANTHEON_HOSTNAME' ) ) {
 		$site_name = $_ENV['PANTHEON_SITE_NAME'];
 		$hostname = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : $_ENV['PANTHEON_ENVIRONMENT'] . "-{$site_name}.pantheonsite.io";

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -25,6 +25,22 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	if ( ! isset( $_ENV['LANDO'] ) ) {
 		// Define appropriate location for default tmp directory on Pantheon.
 		Config::define( 'WP_TEMP_DIR', sys_get_temp_dir() );
+
+		// Set WP_ENVIRONMENT_TYPE according to the Pantheon Environment
+		if ( getenv( 'WP_ENVIRONMENT_TYPE' ) === false ) {
+			switch ( $_ENV['PANTHEON_ENVIRONMENT'] ) {
+				case 'live':
+					putenv( 'WP_ENVIRONMENT_TYPE=production' );
+					break;
+				case 'test':
+					putenv( 'WP_ENVIRONMENT_TYPE=staging' );
+					break;
+				default:
+					putenv( 'WP_ENVIRONMENT_TYPE=development' );
+					break;
+			}
+		}
+
 		// We can use PANTHEON_SITE_NAME here because it's safe to assume we're on a Pantheon environment if PANTHEON_ENVIRONMENT is set.
 		$sitename = $_ENV['PANTHEON_SITE_NAME'];
 		$baseurl = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $sitename . '.pantheonsite.io';

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -26,7 +26,7 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		// Define appropriate location for default tmp directory on Pantheon.
 		Config::define( 'WP_TEMP_DIR', sys_get_temp_dir() );
 
-		// Set WP_ENVIRONMENT_TYPE according to the Pantheon Environment
+		// Set WP_ENVIRONMENT_TYPE according to the Pantheon Environment.
 		if ( getenv( 'WP_ENVIRONMENT_TYPE' ) === false ) {
 			switch ( $_ENV['PANTHEON_ENVIRONMENT'] ) {
 				case 'live':
@@ -72,7 +72,7 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		 * We make an explicit exception here for multisite because there are cases where multisite does not work properly when WP_Cron is disabled.
 		 * We only define DISABLE_WP_CRON if it's not already defined, which means you can override it in the application.php (though we don't recommend it).
 		 */
-		$network = isset( $_ENV["FRAMEWORK"] ) && $_ENV["FRAMEWORK"] === 'wordpress_network';
+		$network = isset( $_ENV['FRAMEWORK'] ) && $_ENV['FRAMEWORK'] === 'wordpress_network';
 		if ( ! defined( 'DISABLE_WP_CRON' ) && ! env( 'DISABLE_WP_CRON' ) && $network === false ) {
 			Config::define( 'DISABLE_WP_CRON', true );
 		}

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -19,8 +19,12 @@ defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
 defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
 defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );
 
+// Pantheon-specific settings.
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+	// These settings do not apply when using Lando local.
 	if ( ! isset( $_ENV['LANDO'] ) ) {
+		// Define appropriate location for default tmp directory on Pantheon.
+		Config::define( 'WP_TEMP_DIR', sys_get_temp_dir() );
 		// We can use PANTHEON_SITE_NAME here because it's safe to assume we're on a Pantheon environment if PANTHEON_ENVIRONMENT is set.
 		$sitename = $_ENV['PANTHEON_SITE_NAME'];
 		$baseurl = $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $sitename . '.pantheonsite.io';

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -67,15 +67,15 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 			}
 		}
 
-        /**
-         * Disable wp-cron.php from running on every page load and rely on Pantheon to run cron via wp-cli.
-         * We make an explicit exception here for multisite because there are cases where multisite does not work properly when WP_Cron is disabled.
-         * We only define DISABLE_WP_CRON if it's not already defined, which means you can override it in the application.php (though we don't recommend it).
-         */
-        $network = isset( $_ENV["FRAMEWORK"] ) && $_ENV["FRAMEWORK"] === 'wordpress_network';
-        if ( ! defined( 'DISABLE_WP_CRON' ) && ! env( 'DISABLE_WP_CRON' ) && $network === false ) {
-            Config::define( 'DISABLE_WP_CRON', true );
-        }
+		/**
+		 * Disable wp-cron.php from running on every page load and rely on Pantheon to run cron via wp-cli.
+		 * We make an explicit exception here for multisite because there are cases where multisite does not work properly when WP_Cron is disabled.
+		 * We only define DISABLE_WP_CRON if it's not already defined, which means you can override it in the application.php (though we don't recommend it).
+		 */
+		$network = isset( $_ENV["FRAMEWORK"] ) && $_ENV["FRAMEWORK"] === 'wordpress_network';
+		if ( ! defined( 'DISABLE_WP_CRON' ) && ! env( 'DISABLE_WP_CRON' ) && $network === false ) {
+			Config::define( 'DISABLE_WP_CRON', true );
+		}
 	}
 
 	// Define PANTHEON_HOSTNAME.

--- a/config/application.php
+++ b/config/application.php
@@ -91,7 +91,6 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && ! isset( $_ENV['LANDO'] ) ) {
 	Config::define( 'WP_HOME', env( 'WP_HOME' ) );
 	Config::define( 'WP_SITEURL', env( 'WP_SITEURL' ) );
 	Config::define( 'DB_HOST', env( 'DB_HOST' ) ?: 'localhost' );
-	Config::define( 'DISABLE_WP_CRON', env( 'DISABLE_WP_CRON' ) ?: false );
 }
 
 /**

--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -1,70 +1,9 @@
 <?php
 /**
- * Pantheon platform settings.
+ * Pantheon wp-config file.
  *
- * IMPORTANT NOTE:
- * Do not modify this file. This file is maintained by Pantheon.
+ * This file is an artifact and has no content. It is not loaded by wp-config (Pantheon-specific configurations have been moved to config/application.pantheon.php).
  *
- * Site-specific modifications belong in wp-config.php, not this file.
- * This file may change in future releases and modifications would cause
- * conflicts when attempting to apply upstream updates.
+ * This file can be deleted and will never be updated.
+ * If you're interested in an example of a wp-config-pantheon.php file for reference, see https://github.com/pantheon-systems/WordPress/blob/default/wp-config-pantheon.php.
  */
-
-use Roots\WPConfig\Config;
-use function Env\env;
-
-/** A couple extra tweaks to help things run well on Pantheon. **/
-if (isset($_SERVER['HTTP_HOST'])) {
-    // HTTP is still the default scheme for now.
-    $scheme = 'http';
-    // If we have detected that the end use is HTTPS, make sure we pass that
-    // through here, so <img> tags and the like don't generate mixed-mode
-    // content warnings.
-    if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON') {
-        $scheme = 'https';
-        $_SERVER['HTTPS'] = 'on';
-    }
-    Config::define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
-    Config::define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST'] . '/wp');
-}
-
-// Don't show deprecations; useful under PHP 5.5
-error_reporting(E_ALL ^ E_DEPRECATED);
-/** Define appropriate location for default tmp directory on Pantheon */
-define('WP_TEMP_DIR', sys_get_temp_dir());
-
-/**
- * Set WP_ENVIRONMENT_TYPE according to the Pantheon Environment
- */
-if (getenv('WP_ENVIRONMENT_TYPE') === false) {
-    switch ($_ENV['PANTHEON_ENVIRONMENT']) {
-        case 'live':
-            putenv('WP_ENVIRONMENT_TYPE=production');
-            break;
-        case 'test':
-            putenv('WP_ENVIRONMENT_TYPE=staging');
-            break;
-        default:
-            putenv('WP_ENVIRONMENT_TYPE=development');
-            break;
-    }
-}
-
-/**
- * Force SSL
- */
-if ( ! env('FORCE_SSL_ADMIN') ) {
-    Config::define( 'FORCE_SSL_ADMIN', true );
-}
-
-/**
- * Defaults you may override
- *
- * To override, define your constant in your wp-config.php before wp-config-pantheon.php is required.
- */
-
-/** Disable wp-cron.php from running on every page load and rely on Pantheon to run cron via wp-cli */
-$network = isset($_ENV["FRAMEWORK"]) && $_ENV["FRAMEWORK"] === "wordpress_network";
-if ( ! env( 'DISABLE_WP_CRON' ) && $network === false ) {
-	Config::define('DISABLE_WP_CRON', true);
-}

--- a/web/wp-config-pantheon.php
+++ b/web/wp-config-pantheon.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Pantheon wp-config file.
- *
- * This file is an artifact and has no content. It is not loaded by wp-config (Pantheon-specific configurations have been moved to config/application.pantheon.php).
- *
- * This file can be deleted and will never be updated.
- * If you're interested in an example of a wp-config-pantheon.php file for reference, see https://github.com/pantheon-systems/WordPress/blob/default/wp-config-pantheon.php.
- */

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -2,7 +2,7 @@
 /**
  * This is where you should at your configuration customizations. It will work out of the box on Pantheon
  * but you may find there are a lot of neat tricks to be used here.'
- * 
+ *
  * For local development, see .env.local-sample.
  *
  * See our documentation for more details:
@@ -13,11 +13,8 @@
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 /**
- * Pantheon platform settings. Everything you need should already be set.
+ * Pantheon platform settings are defined in config/application.pantheon.php which is called by config/application.php. Everything you need should already be set.
  */
-if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['PANTHEON_ENVIRONMENT']) && ('lando' !== $_ENV['PANTHEON_ENVIRONMENT'])) {
-	require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
-}
 
 require_once dirname(__DIR__) . '/config/application.php';
 


### PR DESCRIPTION
This PR solves several issues.

First and foremost, it resolves an issue created by the fact that `DISABLE_WP_CRON` was defined _twice_ (once in `application.php` and once in `wp-config-pantheon.php`).

The line in `application.php` has been removed.

The second important change here is that we've moved everything from `wp-config-pantheon.php` into `config/application.pantheon.php`. This puts all the Pantheon-specific settings in one place, in the `config` folder (where Bedrock likes it). The `wp-config-pantheon.php` file is retained for legacy reasons but the require is removed from `wp-config.php` (which should not be edited by users on Bedrock sites). The `DISABLE_WP_CRON` constant is defined in `application.pantheon.php` as a value that can be overridden if set before the file is loaded in `application.php` (which allows users the ability to change it if they really need to). Inline comments have been added to reiterate that this is _not_ recommended as well as points out that we do _not_ disable WP Cron on multisite (which the previous comment did not reference at all).