### PR TITLE
[CMSP-1140] Move cookie settings down to use Pantheon hostname

### DIFF
--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -13,12 +13,6 @@
 use Roots\WPConfig\Config;
 use function Env\env;
 
-// Cookie settings.
-defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', $_SERVER['HTTP_HOST'] );
-defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
-defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
-defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );
-
 // Pantheon-specific settings.
 if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	// These settings do not apply when using Lando local.
@@ -86,3 +80,9 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		define( 'PANTHEON_HOSTNAME', $hostname );
 	}
 }
+
+// Cookie settings.
+defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', PANTHEON_HOSTNAME );
+defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
+defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
+defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );


### PR DESCRIPTION
This pull request resolves a minor bug discovered while testing #140 in which HTTP_HOST was not defined when it was being called for the cookie settings.

Since this is the problem that `PANTHEON_HOSTNAME` solves, the PR moves the cookie settings down in the `application.pantheon.php` code so that we can use the `PANTHEON_HOSTNAME` value. This ensures that the cookie domain, admin cookie path, cookie path, and site cookie path are correctly defined for the Pantheon environment.