### PR TITLE
[SITE-1140] fix subdirectory paths

### DIFF
--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -16,8 +16,7 @@ jobs:
         run: |
           CBF=false
           composer install
-          composer lint:phpcbf || true
-          if [ $? -ne 0 ]; then
+          if ! composer lint:phpcbf; then
             echo "cbf=true" >> $GITHUB_ENV
           else
             echo "cbf=false" >> $GITHUB_ENV

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -23,7 +23,6 @@ jobs:
             echo "cbf=false" >> $GITHUB_ENV
           fi
       - name: Commit changes to PR
-        id: git-auto-commit
         if: env.cbf == 'true'
         run: |
           git config --global user.email "bot@getpantheon.com"

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -1,0 +1,47 @@
+name: PHP Code Beautifier
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  phpcbf:
+    name: PHPCBF & Commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Install Composer dependencies and run PHPCBF
+        run: |
+          CBF=false
+          composer install
+          composer lint:phpcbf || true
+          if [ $? -ne 0 ]; then
+            echo "cbf=true" >> $GITHUB_ENV
+          else
+            echo "cbf=false" >> $GITHUB_ENV
+          fi
+      - name: Commit changes to PR
+        id: git-auto-commit
+        if: env.cbf == 'true'
+        run: |
+          git config --global user.email "bot@getpantheon.com"
+          git config --global user.name "Pantheon Robot"
+          DIFF=$(git diff-index --quiet HEAD || echo "true")
+          if [ "$DIFF" == "true" ]; then
+            CHANGES_DETECTED=true
+            git add *.php
+            git commit -m "PHPCBF: Fix coding standards" --no-verify
+            git push origin ${{ github.event.pull_request.head.ref }} || CHANGES_DETECTED=false
+            echo "changes_detected=$CHANGES_DETECTED" >> $GITHUB_ENV
+          else
+            echo "changes_detected=false" >> $GITHUB_ENV
+          fi
+      - name: Add PR Comment
+        if: env.changes_detected == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_COMMIT=$(git rev-parse --short HEAD)
+          gh pr comment ${{ github.event.pull_request.number }} -b "Hi from your friendly robot! :robot: I fixed PHPCS issues with \`phpcbf\` on $CURRENT_COMMIT. Please review the changes."

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -26,8 +26,7 @@ jobs:
         run: |
           git config --global user.email "bot@getpantheon.com"
           git config --global user.name "Pantheon Robot"
-          DIFF=$(git diff-index --quiet HEAD || echo "true")
-          if [ "$DIFF" == "true" ]; then
+          if ! git diff-index --quiet HEAD; then
             CHANGES_DETECTED=true
             git add *.php
             git commit -m "PHPCBF: Fix coding standards" --no-verify

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -62,22 +62,14 @@ function fix_core_resource_urls( string $url ) : string {
 	}
 
 	$path = $parsed_url['path'];
-	$core_paths = [ 'wp-includes/', 'wp-admin/', 'wp-content/' ];
+	$core_paths = [ '/wp-includes/', '/wp-content/' ];
 	$path_modified = false;
 
 	foreach ( $core_paths as $core_path ) {
 		if ( strpos( $path, $current_site_path . $core_path ) !== false ) {
 			$path = str_replace( $current_site_path . $core_path, $core_path, $path );
 			$path_modified = true;
-		}
-
-		if ( str_contains( $path, 'wp' ) ) {
-			$path = str_replace( '/wp/', '/', $path );
-			$path_modified = true;
-		}
-
-		if ( $path_modified ) {
-			break;
+            break;
 		}
 	}
 
@@ -164,26 +156,6 @@ function adjust_main_site_urls( string $url ) : string {
 }
 add_filter( 'home_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
 add_filter( 'site_url', __NAMESPACE__ . '\\adjust_main_site_urls', 9 );
-
-/**
- * Add /wp prefix to all admin and login URLs.
- * Since /wp is where the core files are installed, this normalizes all non-front-facing urls to use the correct url structure.
- *
- * @since 1.1.0
- * @param string $url The URL to check.
- * @return string The corrected admin or login URL (or the base url if not an admin or login url).
- */
-function add_wp_prefix_to_login_and_admin_urls( string $url ) : string {
-	if (  ! __is_login_url( $url ) ) {
-		return $url;
-	}
-	if ( strpos( $url, '/wp/' ) !== false ) {
-		return $url;
-	}
-	return __normalize_wp_url( preg_replace( '/(\/wp-(login|admin))/', '/wp/$1', $url ) );
-}
-add_filter( 'login_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
-add_filter( 'admin_url', __NAMESPACE__ . '\\add_wp_prefix_to_login_and_admin_urls', 9 );
 
 /**
  * Check the URL to see if it's either an admin or wp-login URL.


### PR DESCRIPTION
This pull request removes the unnecessary code for handling wp-admin URLs. The code was not working as intended and caused issues.

This has been tested on a subdirectory multisite (which was the only thing that was broken or affected). Subdomain multisite should be unaffected (there are conditionals specifically targeting subdirectory multisite) but will be tested as well assuming automated tests pass.

The primary issue was admin URLs which are not (currently) tested with automated testing.

Ported from #142