### PR TITLE
[SITE-1585] Move check-commits into GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
     - name: Check Commits
       run: |
+        # Don't warn about detached head.
+        git config variable advice.detachedHead false
         git fetch --all
         git checkout -b default origin/default
         git checkout ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,17 @@ jobs:
         CI: 1
       run: |
           bats -p -t .github/tests
+
+    - name: Create failure status artifact
+      if: failure()
+      run: echo "1" > status.txt
+    - name: Create success status artifact
+      if: success()
+      run: echo "0" > status.txt
+
+    - name: Upload status artifact
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: status
+        path: status.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,9 @@ jobs:
         if [ ! -f status-${{ matrix.php-version }}-${{ github.sha }}.txt ]; then
           echo "0" > status-${{ matrix.php-version }}-${{ github.sha }}.txt
         fi
+
+    - name: Upload status artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: status-${{ matrix.php-version }}-${{ github.sha }}
+        path: status-${{ matrix.php-version }}-${{ github.sha }}.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     - name: Check Commits
       run: |
         git fetch --all
+        git checkout origin/default
+        git checkout ${{ github.event.pull_request.head.sha }}
         echo "This script does preliminary checks to make sure that the commits in a PR made in this repository are ready for the deploy-public-upstream script. i.e. any given commit modifies either 'normal' or 'non-release' files, never mixed."
         bash ${{ github.workspace }}/devops/scripts/check-commits.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,15 @@ jobs:
   generate-aggregate-status:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        php-version: ['8.1', '8.2', '8.3']
+
     steps:
     - name: Download status artifacts
       uses: actions/download-artifact@v4
       with:
-        name: status-*
+        name: status-${{ matrix.php-version }}
 
     - name: Aggregate status
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Check Commits
       run: |
         echo "This script does preliminary checks to make sure that the commits in a PR made in this repository are ready for the deploy-public-upstream script. i.e. any given commit modifies either 'normal' or 'non-release' files, never mixed."
-        bash devops/scripts/check-commits.sh
+        bash ${{ github.workspace }}/devops/scripts/check-commits.sh
 
     - name: Check Composer lock file is up to date
       run: composer validate --no-check-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
     - name: Check Commits
       run: |
+        git fetch --all
         echo "This script does preliminary checks to make sure that the commits in a PR made in this repository are ready for the deploy-public-upstream script. i.e. any given commit modifies either 'normal' or 'non-release' files, never mixed."
         bash ${{ github.workspace }}/devops/scripts/check-commits.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,18 @@ jobs:
       run: |
           bats -p -t .github/tests
 
-    - name: Dispatch Playwright tests
-      if: success()
-      env:
-        GH_TOKEN: ${{ github.token }}
+    - name: Create failure status artifact
+      if: failure()
       run: |
-        gh workflow run playwright.yml --ref ${{ github.event.pull_request.head.ref }}
+        # In the case of a failure, remove the previous status, whatever it was, and update it to 1.
+        if [ -f status-${{ matrix.php-version }}.txt ]; then
+          rm status-${{ matrix.php-version }}.txt
+        fi
+        echo "1" > status-${{ matrix.php-version }}.txt
+    - name: Create success status artifact
+      if: success()
+      run: |
+        # Only create a status file if it doesn't already exist.
+        if [ ! -f status-${{ matrix.php-version }}.txt ]; then
+          echo "0" > status-${{ matrix.php-version }}.txt
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Check Commits
       run: |
         # Don't warn about detached head.
-        git config variable advice.detachedHead false
+        git config advice.detachedHead false
         git fetch --all
         git checkout -b default origin/default
         git checkout ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
         restore-keys: ${{ runner.os }}-composer-
 
+    - name: Check Commits
+      run: |
+        echo "This script does preliminary checks to make sure that the commits in a PR made in this repository are ready for the deploy-public-upstream script. i.e. any given commit modifies either 'normal' or 'non-release' files, never mixed."
+        bash devops/scripts/check-commits.sh
+
     - name: Check Composer lock file is up to date
       run: composer validate --no-check-all
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 
 permissions:
     contents: write
+    actions: read
+    id-token: write
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,34 +91,3 @@ jobs:
       with:
         name: status-${{ matrix.php-version }}
         path: status-${{ matrix.php-version }}.txt
-
-  generate-aggregate-status:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        php-version: ['8.1', '8.2', '8.3']
-
-    steps:
-    - name: Download status artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: status-${{ matrix.php-version }}
-
-    - name: Aggregate status
-      run: |
-        # If any of the status files contain a 1, then the aggregate status is 1.
-        for file in status-*.txt; do
-          if [ "$(cat $file)" == "1" ]; then
-            echo "1" > status.txt
-            exit 0
-          fi
-          # If we get here, then the status is 0.
-          echo "0" > status.txt
-        done
-
-    - name: Upload aggregate status
-      uses: actions/upload-artifact@v4
-      with:
-        name: status
-        path: status.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,21 +73,48 @@ jobs:
       if: failure()
       run: |
         # In the case of a failure, remove the previous status, whatever it was, and update it to 1.
-        if [ -f status.txt ]; then
-          rm status.txt
+        if [ -f status-*.txt ]; then
+          rm status-*.txt
         fi
-        echo "1" > status.txt
+        echo "1" > status-${{ matrix.php-version }}.txt
     - name: Create success status artifact
       if: success()
       run: |
         # Only create a status file if it doesn't already exist.
         if [ ! -f status.txt ]; then
-          echo "0" > status.txt
+          echo "0" > status-${{ matrix.php-version }}.txt
         fi
 
     - name: Upload status artifact
       uses: actions/upload-artifact@v4
       if: always()
+      with:
+        name: status-${{ matrix.php-version }}
+        path: status-${{ matrix.php-version }}.txt
+
+  generate-aggregate-status:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Download status artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: status-*
+
+    - name: Aggregate status
+      run: |
+        # If any of the status files contain a 1, then the aggregate status is 1.
+        for file in status-*.txt; do
+          if [ "$(cat $file)" == "1" ]; then
+            echo "1" > status.txt
+            exit 0
+          fi
+          # If we get here, then the status is 0.
+          echo "0" > status.txt
+        done
+
+    - name: Upload aggregate status
+      uses: actions/upload-artifact@v4
       with:
         name: status
         path: status.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,25 +71,7 @@ jobs:
       run: |
           bats -p -t .github/tests
 
-    - name: Create failure status artifact
-      if: failure()
-      run: |
-        # In the case of a failure, remove the previous status, whatever it was, and update it to 1.
-        if [ -f status-*.txt ]; then
-          rm status-*.txt
-        fi
-        echo "1" > status-${{ matrix.php-version }}.txt
-    - name: Create success status artifact
+    - name: Dispatch Playwright tests
       if: success()
       run: |
-        # Only create a status file if it doesn't already exist.
-        if [ ! -f status.txt ]; then
-          echo "0" > status-${{ matrix.php-version }}.txt
-        fi
-
-    - name: Upload status artifact
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: status-${{ matrix.php-version }}
-        path: status-${{ matrix.php-version }}.txt
+        gh workflow run playwright.yml --ref ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,14 +75,14 @@ jobs:
       if: failure()
       run: |
         # In the case of a failure, remove the previous status, whatever it was, and update it to 1.
-        if [ -f status-${{ matrix.php-version }}.txt ]; then
-          rm status-${{ matrix.php-version }}.txt
+        if [ -f status-${{ matrix.php-version }}-${{ github.sha }}.txt ]; then
+          rm status-${{ matrix.php-version }}-${{ github.sha }}.txt
         fi
-        echo "1" > status-${{ matrix.php-version }}.txt
+        echo "1" > status-${{ matrix.php-version }}-${{ github.sha }}.txt
     - name: Create success status artifact
       if: success()
       run: |
         # Only create a status file if it doesn't already exist.
-        if [ ! -f status-${{ matrix.php-version }}.txt ]; then
-          echo "0" > status-${{ matrix.php-version }}.txt
+        if [ ! -f status-${{ matrix.php-version }}-${{ github.sha }}.txt ]; then
+          echo "0" > status-${{ matrix.php-version }}-${{ github.sha }}.txt
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,19 @@ jobs:
 
     - name: Create failure status artifact
       if: failure()
-      run: echo "1" > status.txt
+      run: |
+        # In the case of a failure, remove the previous status, whatever it was, and update it to 1.
+        if [ -f status.txt ]; then
+          rm status.txt
+        fi
+        echo "1" > status.txt
     - name: Create success status artifact
       if: success()
-      run: echo "0" > status.txt
+      run: |
+        # Only create a status file if it doesn't already exist.
+        if [ ! -f status.txt ]; then
+          echo "0" > status.txt
+        fi
 
     - name: Upload status artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,13 @@ jobs:
         git checkout -b default origin/default
         git checkout ${{ github.event.pull_request.head.sha }}
         echo "This script does preliminary checks to make sure that the commits in a PR made in this repository are ready for the deploy-public-upstream script. i.e. any given commit modifies either 'normal' or 'non-release' files, never mixed."
-        bash ${{ github.workspace }}/devops/scripts/check-commits.sh
+        bash ${{ github.workspace }}/devops/scripts/check-commits.sh || echo "commit_check_failed=1" >> $GITHUB_ENV
+
+    - name: Comment on PR if commit check failed
+      if: env.commit_check_failed == '1'
+      run: |
+        gh pr comment ${{ github.event.pull_request.number }} -b "Hi from your friendly robot! :robot: It looks like there might be commits to both release and non-release files in this PR. Please review and remove any commits that don't belong."
+        exit 1
 
     - name: Check Composer lock file is up to date
       run: composer validate --no-check-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Check Commits
       run: |
         git fetch --all
-        git checkout origin/default
+        git checkout -b default origin/default
         git checkout ${{ github.event.pull_request.head.sha }}
         echo "This script does preliminary checks to make sure that the commits in a PR made in this repository are ready for the deploy-public-upstream script. i.e. any given commit modifies either 'normal' or 'non-release' files, never mixed."
         bash ${{ github.workspace }}/devops/scripts/check-commits.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,7 @@ jobs:
 
     - name: Dispatch Playwright tests
       if: success()
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh workflow run playwright.yml --ref ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 permissions:
     contents: write
     actions: read
-    id-token: write
+    pull-requests: write
 
 jobs:
   build:
@@ -50,6 +50,8 @@ jobs:
 
     - name: Comment on PR if commit check failed
       if: env.commit_check_failed == '1'
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh pr comment ${{ github.event.pull_request.number }} -b "Hi from your friendly robot! :robot: It looks like there might be commits to both release and non-release files in this PR. Please review and remove any commits that don't belong."
         exit 1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,13 +34,11 @@ jobs:
 
           while [ $attempt -lt $max_attempts ]; do
             # Attempt to download the artifacts.
-            gh run download -n status-8.1-${{ github.sha }}
-            gh run download -n status-8.2-${{ github.sha }}
-            gh run download -n status-8.3-${{ github.sha }}
+            gh run download -n status-8.1-${{ github.sha }} || true
+            gh run download -n status-8.2-${{ github.sha }} || true
+            gh run download -n status-8.3-${{ github.sha }} || true
 
             if [ -f status-8.1-${{ github.sha }}.txt ] && [ -f status-8.2-${{ github.sha }}.txt ] && [ -f status-8.3-${{ github.sha }}.txt ]; then
-              ls status-*.txt
-              echo "All status files found."
               success=1
               break
             else
@@ -164,9 +162,9 @@ jobs:
 
           while [ $attempt -lt $max_attempts ]; do
             # Attempt to download the artifacts.
-            gh run download -n status-8.1-${{ github.sha }}
-            gh run download -n status-8.2-${{ github.sha }}
-            gh run download -n status-8.3-${{ github.sha }}
+            gh run download -n status-8.1-${{ github.sha }} || true
+            gh run download -n status-8.2-${{ github.sha }} || true
+            gh run download -n status-8.3-${{ github.sha }} || true
 
             if [ -f status-8.1-${{ github.sha }}.txt ] && [ -f status-8.2-${{ github.sha }}.txt ] && [ -f status-8.3-${{ github.sha }}.txt ]; then
               success=1
@@ -297,9 +295,9 @@ jobs:
 
           while [ $attempt -lt $max_attempts ]; do
             # Attempt to download the artifacts.
-            gh run download -n status-8.1-${{ github.sha }}
-            gh run download -n status-8.2-${{ github.sha }}
-            gh run download -n status-8.3-${{ github.sha }}
+            gh run download -n status-8.1-${{ github.sha }} || true
+            gh run download -n status-8.2-${{ github.sha }} || true
+            gh run download -n status-8.3-${{ github.sha }} || true
 
             if [ -f status-8.1-${{ github.sha }}.txt ] && [ -f status-8.2-${{ github.sha }}.txt ] && [ -f status-8.3-${{ github.sha }}.txt ]; then
               success=1

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,6 @@
 name: WordPress Composer Playwright Tests
 on:
-  workflow_run:
-    workflows: ["Lint and Test"]
-    types:
-      - completed
+  workflow_dispatch:
 
 permissions:
     contents: write

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -39,6 +39,8 @@ jobs:
             gh run download -n status-8.3
 
             if [ -f status-8.1.txt ] && [ -f status-8.2.txt ] && [ -f status-8.3.txt ]; then
+              ls status-*.txt
+              echo "All status files found."
               success=1
               break
             else

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,11 +12,6 @@ permissions:
     actions: read
 
 jobs:
-  test-job:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Note success
-        run: echo "Triggered workflow started"
 
   playwright-single:
     name: Single site

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,11 @@
 name: WordPress Composer Playwright Tests
 on:
-  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
     contents: write

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,11 +1,9 @@
 name: WordPress Composer Playwright Tests
 on:
-  pull_request:
+  workflow_run:
+    workflows: ["Lint and Test"]
     types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
+      - completed
 
 permissions:
     contents: write
@@ -17,6 +15,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download build status artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: status
+
+      - name: Check status
+        id: check-status
+        run: |
+          status=$(cat status.txt)
+          echo "status=$status" >> $GITHUB_ENV
+
+      - name: Linting failed
+        if: env.status == '1'
+        run: exit 1
 
       - name: Get last commit message
         env:
@@ -97,6 +110,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download build status artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: status
+
+      - name: Check status
+        id: check-status
+        run: |
+          status=$(cat status.txt)
+          echo "status=$status" >> $GITHUB_ENV
+
+      - name: Linting failed
+        if: env.status == '1'
+        run: exit 1
 
       - name: Get last commit message
         env:
@@ -182,6 +210,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download build status artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: status
+
+      - name: Check status
+        id: check-status
+        run: |
+          status=$(cat status.txt)
+          echo "status=$status" >> $GITHUB_ENV
+
+      - name: Linting failed
+        if: env.status == '1'
+        run: exit 1
 
       - name: Get last commit message
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,8 +7,15 @@ on:
 
 permissions:
     contents: write
+    actions: read
 
 jobs:
+  test-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Note success
+        run: echo "Triggered workflow started"
+
   playwright-single:
     name: Single site
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -60,6 +60,8 @@ jobs:
               exit 1
             fi
           done
+
+          echo "Linting tests passed. Proceeding with Playwright tests. ✅"
           echo "status=$status" >> $GITHUB_ENV
 
       - name: Linting failed

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -59,6 +59,7 @@ jobs:
               echo "status=$status" >> $GITHUB_ENV
               exit 1
             fi
+          done
           echo "status=$status" >> $GITHUB_ENV
 
       - name: Linting failed
@@ -186,6 +187,7 @@ jobs:
               echo "status=$status" >> $GITHUB_ENV
               exit 1
             fi
+          done
           echo "status=$status" >> $GITHUB_ENV
 
       - name: Linting failed
@@ -318,6 +320,7 @@ jobs:
               echo "status=$status" >> $GITHUB_ENV
               exit 1
             fi
+          done
           echo "status=$status" >> $GITHUB_ENV
 
       - name: Linting failed

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -211,20 +211,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download build status artifact
+      - name: Download 8.1 build status artifact
         uses: actions/download-artifact@v4
         with:
-          name: status
+          name: status-8.1
+
+      - name: Download 8.2 build status artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: status-8.2
+
+      - name: Download 8.3 build status artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: status-8.3
 
       - name: Check status
         id: check-status
         run: |
-          status=$(cat status.txt)
+          status=0
+          for file in status-*.txt; do
+            status=$(cat $file)
+            if [ $status -eq 1 ]; then
+              echo "status=$status" >> $GITHUB_ENV
+              exit 1
+            fi
           echo "status=$status" >> $GITHUB_ENV
 
       - name: Linting failed
         if: env.status == '1'
-        run: exit 1
+        run: |
+          echo "One or more jobs in a previous workflow failed. Exiting."
+          exit 1
 
       - name: Get last commit message
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,11 +34,11 @@ jobs:
 
           while [ $attempt -lt $max_attempts ]; do
             # Attempt to download the artifacts.
-            gh run download -n status-8.1
-            gh run download -n status-8.2
-            gh run download -n status-8.3
+            gh run download -n status-8.1-${{ github.sha }}
+            gh run download -n status-8.2-${{ github.sha }}
+            gh run download -n status-8.3-${{ github.sha }}
 
-            if [ -f status-8.1.txt ] && [ -f status-8.2.txt ] && [ -f status-8.3.txt ]; then
+            if [ -f status-8.1-${{ github.sha }}.txt ] && [ -f status-8.2-${{ github.sha }}.txt ] && [ -f status-8.3-${{ github.sha }}.txt ]; then
               ls status-*.txt
               echo "All status files found."
               success=1
@@ -164,11 +164,11 @@ jobs:
 
           while [ $attempt -lt $max_attempts ]; do
             # Attempt to download the artifacts.
-            gh run download -n status-8.1
-            gh run download -n status-8.2
-            gh run download -n status-8.3
+            gh run download -n status-8.1-${{ github.sha }}
+            gh run download -n status-8.2-${{ github.sha }}
+            gh run download -n status-8.3-${{ github.sha }}
 
-            if [ -f status-8.1.txt ] && [ -f status-8.2.txt ] && [ -f status-8.3.txt ]; then
+            if [ -f status-8.1-${{ github.sha }}.txt ] && [ -f status-8.2-${{ github.sha }}.txt ] && [ -f status-8.3-${{ github.sha }}.txt ]; then
               success=1
               break
             else
@@ -297,11 +297,11 @@ jobs:
 
           while [ $attempt -lt $max_attempts ]; do
             # Attempt to download the artifacts.
-            gh run download -n status-8.1
-            gh run download -n status-8.2
-            gh run download -n status-8.3
+            gh run download -n status-8.1-${{ github.sha }}
+            gh run download -n status-8.2-${{ github.sha }}
+            gh run download -n status-8.3-${{ github.sha }}
 
-            if [ -f status-8.1.txt ] && [ -f status-8.2.txt ] && [ -f status-8.3.txt ]; then
+            if [ -f status-8.1-${{ github.sha }}.txt ] && [ -f status-8.2-${{ github.sha }}.txt ] && [ -f status-8.3-${{ github.sha }}.txt ]; then
               success=1
               break
             else

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,6 +25,53 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Wait for status artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          max_attempts=10
+          delay_seconds=30
+          attempt=0
+          success=0
+          status=0
+
+          echo "Checking for status artifacts..."
+
+          while [ $attempt -lt $max_attempts ]; do
+            # Attempt to download the artifacts.
+            gh run download -n status-8.1
+            gh run download -n status-8.2
+            gh run download -n status-8.3
+
+            if [ -f status-8.1.txt ] && [ -f status-8.2.txt ] && [ -f status-8.3.txt ]; then
+              success=1
+              break
+            else
+              echo "Status files not found. Sleeping for $delay_seconds seconds..."
+              sleep $delay_seconds
+            fi
+            attempt=$(( attempt + 1 ))
+          done
+
+          if [ $success -eq 0 ]; then
+            echo "Timed out waiting for status artifacts."
+            exit 1
+          fi
+
+          for file in status-*.txt; do
+            status=$(cat $file)
+            if [ $status -eq 1 ]; then
+              echo "status=$status" >> $GITHUB_ENV
+              exit 1
+            fi
+          echo "status=$status" >> $GITHUB_ENV
+
+      - name: Linting failed
+        if: env.status == '1'
+        run: |
+          echo "One or more jobs in a previous workflow failed. Exiting."
+          exit 1
+
       - name: Get last commit message
         env:
           GH_TOKEN: ${{ github.token }}
@@ -104,6 +151,53 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Wait for status artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          max_attempts=10
+          delay_seconds=30
+          attempt=0
+          success=0
+          status=0
+
+          echo "Checking for status artifacts..."
+
+          while [ $attempt -lt $max_attempts ]; do
+            # Attempt to download the artifacts.
+            gh run download -n status-8.1
+            gh run download -n status-8.2
+            gh run download -n status-8.3
+
+            if [ -f status-8.1.txt ] && [ -f status-8.2.txt ] && [ -f status-8.3.txt ]; then
+              success=1
+              break
+            else
+              echo "Status files not found. Sleeping for $delay_seconds seconds..."
+              sleep $delay_seconds
+            fi
+            attempt=$(( attempt + 1 ))
+          done
+
+          if [ $success -eq 0 ]; then
+            echo "Timed out waiting for status artifacts."
+            exit 1
+          fi
+
+          for file in status-*.txt; do
+            status=$(cat $file)
+            if [ $status -eq 1 ]; then
+              echo "status=$status" >> $GITHUB_ENV
+              exit 1
+            fi
+          echo "status=$status" >> $GITHUB_ENV
+
+      - name: Linting failed
+        if: env.status == '1'
+        run: |
+          echo "One or more jobs in a previous workflow failed. Exiting."
+          exit 1
 
       - name: Get last commit message
         env:
@@ -189,6 +283,47 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Wait for status artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          max_attempts=10
+          delay_seconds=30
+          attempt=0
+          success=0
+          status=0
+
+          echo "Checking for status artifacts..."
+
+          while [ $attempt -lt $max_attempts ]; do
+            # Attempt to download the artifacts.
+            gh run download -n status-8.1
+            gh run download -n status-8.2
+            gh run download -n status-8.3
+
+            if [ -f status-8.1.txt ] && [ -f status-8.2.txt ] && [ -f status-8.3.txt ]; then
+              success=1
+              break
+            else
+              echo "Status files not found. Sleeping for $delay_seconds seconds..."
+              sleep $delay_seconds
+            fi
+            attempt=$(( attempt + 1 ))
+          done
+
+          if [ $success -eq 0 ]; then
+            echo "Timed out waiting for status artifacts."
+            exit 1
+          fi
+
+          for file in status-*.txt; do
+            status=$(cat $file)
+            if [ $status -eq 1 ]; then
+              echo "status=$status" >> $GITHUB_ENV
+              exit 1
+            fi
+          echo "status=$status" >> $GITHUB_ENV
 
       - name: Linting failed
         if: env.status == '1'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,21 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download build status artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: status
-
-      - name: Check status
-        id: check-status
-        run: |
-          status=$(cat status.txt)
-          echo "status=$status" >> $GITHUB_ENV
-
-      - name: Linting failed
-        if: env.status == '1'
-        run: exit 1
-
       - name: Get last commit message
         env:
           GH_TOKEN: ${{ github.token }}
@@ -114,21 +99,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download build status artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: status
-
-      - name: Check status
-        id: check-status
-        run: |
-          status=$(cat status.txt)
-          echo "status=$status" >> $GITHUB_ENV
-
-      - name: Linting failed
-        if: env.status == '1'
-        run: exit 1
 
       - name: Get last commit message
         env:
@@ -214,33 +184,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download 8.1 build status artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: status-8.1
-
-      - name: Download 8.2 build status artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: status-8.2
-
-      - name: Download 8.3 build status artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: status-8.3
-
-      - name: Check status
-        id: check-status
-        run: |
-          status=0
-          for file in status-*.txt; do
-            status=$(cat $file)
-            if [ $status -eq 1 ]; then
-              echo "status=$status" >> $GITHUB_ENV
-              exit 1
-            fi
-          echo "status=$status" >> $GITHUB_ENV
 
       - name: Linting failed
         if: env.status == '1'

--- a/devops/scripts/commit-type.sh
+++ b/devops/scripts/commit-type.sh
@@ -35,7 +35,7 @@ function identify_commit_type() {
 # Verifies that the given commit does not contain forbidden files.
 function only_allowed_files() {
   local commit=$1
-  local forbidden_files=("composer.lock" ".github/workflows/ci.yml")
+  local forbidden_files=("composer.lock" "package-lock.json")
   local has_forbidden_files=0
 
   affected_paths=$(git show "${commit}" --pretty=oneline --name-only | tail -n +2)

--- a/devops/scripts/setup-playwright-tests.sh
+++ b/devops/scripts/setup-playwright-tests.sh
@@ -70,7 +70,7 @@ copy_pr_updates() {
   echo "Commit Message: ${commit_msg}"
   cd ~/pantheon-local-copies/"${site_id}"
   echo -e "${YELLOW}Copying latest changes and committing to the site.${RESET}"
-  rsync -a --exclude='.git' "${workspace}"/ .
+  rsync -a --exclude='.git' --exclude='status-*.txt' "${workspace}/" .
   git add -A
   git commit -m "Update to latest commit: ${commit_msg}" || true
   git push origin master || true
@@ -90,7 +90,7 @@ install_wp() {
   if [[ "${type}" == 'subdom' ]]; then
     is_subdomains="true"
   fi
-  
+
   terminus wp "${site_id}".dev -- core multisite-install --title="${site_name}" --admin_user=wpcm --admin_email=test@dev.null --subdomains="$is_subdomains" --url="${site_url}"
 
   terminus wp "${site_id}".dev -- option update permalink_structure '/%postname%/'
@@ -144,7 +144,7 @@ set_up_subsite() {
     else
       # Create the sub-site only if it does not already exist.
       terminus wp "${site_id}".dev -- site create --slug=foo --title="Foo" --email="foo@dev.null"
-      terminus wp "${site_id}".dev -- option update permalink_structure '/%postname%/' --url="$URL"      
+      terminus wp "${site_id}".dev -- option update permalink_structure '/%postname%/' --url="$URL"
     fi
     terminus wp "${site_id}".dev -- option update permalink_structure '/%postname%/' --url="$URL"
 }
@@ -162,7 +162,7 @@ install_wp_graphql() {
   elif [ "${type}" == 'subdir' ]; then
     url="${site_url}/foo"
   fi
-  
+
   # activate if not single site
   if [[ -n "$url" ]]; then
     terminus wp "${site_id}.dev" -- plugin activate wp-graphql --url="$url"


### PR DESCRIPTION
This PR moves the `check-commits` script into a GitHub action workflow. It does not remove it from the deploy workflow, but adding it to a GHA workflow means that if we would mix non-release and release commits in a single PR, we are alerted early because the PR will fail.

This PR also creates a relationship between the Playwright (functional) tests and the linting tests and commit checks. If anything in the linting tests (`ci.yml`) fails, it prevents the Playwright tests from executing.

If the check-commits script fails -- and finds mixed commits to release and non-release files in the same PR -- a message is added to the PR and the workflow fails.

This does not change or fix the issues in the upstream or solve the issue described in SITE-1585, but it will (attempt to) prevent issues that currently exist in the upstream from happening again by failing the PR early.