### PR TITLE
[SITE-1585] address diffs after rebase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
   ],
   "support": {
     "issues": "https://github.com/pantheon-systems/wordpress-composer-managed/issues",
-    "docs": "https://pantheon.io/docs/guides/wordpress-composer",
-    "forum": "https://discuss.pantheon.io"
+    "docs": "https://pantheon.io/docs/guides/wordpress-composer"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,24 @@
 {
-  "name": "roots/bedrock",
+  "name": "pantheon-systems/wordpress-composer-managed",
   "type": "project",
   "license": "MIT",
-  "description": "WordPress boilerplate with Composer, easier configuration, and an improved folder structure",
-  "homepage": "https://roots.io/bedrock/",
+  "description": "Pantheon's recommended starting point for WordPress upstreams using the platform's Integrated Composer build process.",
+  "homepage": "https://pantheon.io/docs/guides/wordpress-composer",
   "authors": [
+    {
+      "name": "Pantheon Systems",
+      "homepage": "https://pantheon.io"
+    },
+    {
+      "name": "John Spellman",
+      "email": "john.spellman@pantheon.io",
+      "homepage": "https://github.com/jspellman814"
+    },
+    {
+      "name": "Chris Reynolds",
+      "email": "chris.reynolds@pantheon.io",
+      "homepage": "https://github.com/jazzsequence"
+    },
     {
       "name": "Scott Walkinshaw",
       "email": "scott.walkinshaw@gmail.com",
@@ -17,11 +31,12 @@
     }
   ],
   "keywords": [
-    "bedrock", "composer", "roots", "wordpress", "wp", "wp-config"
+    "bedrock", "composer", "roots", "wordpress", "wp", "wp-config", "pantheon"
   ],
   "support": {
-    "issues": "https://github.com/roots/bedrock/issues",
-    "forum": "https://discourse.roots.io/category/bedrock"
+    "issues": "https://github.com/pantheon-systems/wordpress-composer-managed/issues",
+    "docs": "https://pantheon.io/docs/guides/wordpress-composer",
+    "forum": "https://discuss.pantheon.io"
   },
   "repositories": [
     {
@@ -76,6 +91,12 @@
       "web/app/themes/{$name}/": ["type:wordpress-theme"]
     },
     "wordpress-install-dir": "web/wp",
+    "build-env": {
+      "install-cms": [
+        "wp core install --title={site-name} --url={site-url} --admin_user={account-name} --admin_email={account-mail} --admin_password={account-pass}",
+        "wp option update permalink_structure '/%postname%/'"
+      ]
+    },
     "composer-scaffold": {
       "locations": {
         "web-root": "./"

--- a/config/application.php
+++ b/config/application.php
@@ -60,13 +60,6 @@ require_once __DIR__ . '/application.pantheon.php';
 define( 'WP_ENV', env( 'WP_ENV' ) ?: 'production' );
 
 /**
- * Custom Content Directory
- */
-Config::define('CONTENT_DIR', '/app');
-Config::define('WP_CONTENT_DIR', $webroot_dir . Config::get('CONTENT_DIR'));
-Config::define('WP_CONTENT_URL', Config::get('WP_HOME') . Config::get('CONTENT_DIR'));
-
-/**
  * DB settings
  */
 Config::define( 'DB_NAME', env( 'DB_NAME' ) );


### PR DESCRIPTION
This PR re-applies fixes from the backed-up copy of WPCM onto files that were changed the wrong way after the rebase.

While this PR doesn't actually address anything related to SITE-1585, rebasing the entire repository on the `pantheon-upstreams` repo, the "fix" was rebasing the repository on `pantheon-usptreams/main` and this fixes files that were adversely affected by the rebase (honestly surprising more didn't break).