### PR TITLE
Get subdomain multisite tests working properly

### DIFF
--- a/.github/tests/wpcm.spec.ts
+++ b/.github/tests/wpcm.spec.ts
@@ -3,6 +3,7 @@ import { test, expect } from "@playwright/test";
 const exampleArticle = "Hello world!";
 const siteTitle = process.env.SITE_NAME || "WPCM Playwright Tests";
 const siteUrl = process.env.SITE_URL || "https://dev-wpcm-playwright-tests.pantheonsite.io";
+let graphqlEndpoint = process.env.GRAPHQL_ENDPOINT || `${siteUrl}/wp/graphql`;
 
 test("homepage loads and contains example content", async ({ page }) => {
   await page.goto(siteUrl);
@@ -41,8 +42,7 @@ test("validate core resource URLs", async ({ request }) => {
 });
 
 test("graphql is able to access hello world post", async ({ request }) => {
-  let graphqlEndpoint = `${siteUrl}/wp/graphql`;
-  let apiRoot = await request.get(`${siteUrl}/wp/graphql`);
+  let apiRoot = await request.get(graphqlEndpoint);
   // If the above request doesn't resolve, it's because we're on a subsite where the path is ${siteUrl}/graphql -- similar to the rest api.
   if (!apiRoot.ok()) {
     graphqlEndpoint = `${siteUrl}/graphql`;

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -439,9 +439,7 @@ jobs:
             exit 1
           fi
           # Check SUBDOMAIN_INSTALL value
-          SUBDOMAIN_INSTALL=$(terminus wp "${{ env.SITE_ID }}".dev -- config get SUBDOMAIN_INSTALL)
-          if [[ "${SUBDOMAIN_INSTALL}" != "1" ]]; then
-            # SUBDOMAIN_INSTALL should be true.
+          if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true SUBDOMAIN_INSTALL; then
               echo -e "Subdomain configuration not found!"
               exit 1
           fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -400,7 +400,7 @@ jobs:
           terminus local:clone ${{ env.SITE_ID }}
           cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"
           echo "Copying latest changes and committing to the site."
-          rsync -a --exclude='.git' --exclude='status-*.txt' "${{ github.workspace }}/" .
+          rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" "${{ github.workspace }}/" .
           git add -A
           git commit -m "Update to latest commit: ${{ env.COMMIT_MSG }}" || true
           git push origin master || true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -393,6 +393,9 @@ jobs:
           git config --global user.email "cms-platform+sage-testing@pantheon.io"
           git config --global user.name "Pantheon WPCM Bot"
 
+          echo "Switching to git mode..."
+          terminus connection:set "${{ env.SITE_ID }}".dev git
+
           echo "Clone the site locally and copy PR updates"
           terminus local:clone ${{ env.SITE_ID }}
           cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -358,6 +358,7 @@ jobs:
           echo "SITE_NAME=$SITE_NAME" >> $GITHUB_ENV
           echo "SITE_URL=$SITE_URL" >> $GITHUB_ENV
           echo "SUBDOMAIN_URL=$SUBDOMAIN_URL" >> $GITHUB_ENV
+          echo "SITE_ID=wpcm-subdom-playwright-tests" >> $GITHUB_ENV
 
       - name: Install SSH keys
         uses: webfactory/ssh-agent@v0.9.0
@@ -385,6 +386,37 @@ jobs:
           echo "Install Playwright Browsers"
           npx playwright install --with-deps
 
+      - name: Copy changes from PR
+        run: |
+          echo "Commit Message: ${{ env.COMMIT_MSG }}"
+          echo "Setting up some git config..."
+          git config --global user.email "cms-platform+sage-testing@pantheon.io"
+          git config --global user.name "Pantheon WPCM Bot"
+
+          echo "Clone the site locally and copy PR updates"
+          terminus local:clone ${{ env.SITE_ID }}
+          cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"
+          echo "Copying latest changes and committing to the site."
+          rsync -a --exclude='.git' --exclude='status-*.txt' "${{ github.workspace }}/" .
+          git add -A
+          git commit -m "Update to latest commit: ${{ env.COMMIT_MSG }}" || true
+          git push origin master || true
+
+          echo "Checking WordPress install status"
+          terminus wp "${{ env.SITE_ID }}".dev -- cli info
+          if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true MULTISITE; then
+            echo -e "${RED}Multisite not found!${RESET}"
+            exit 1
+          fi
+          # Check SUBDOMAIN_INSTALL value
+          SUBDOMAIN_INSTALL=$(terminus wp "${{ env.SITE_ID }}".dev -- config get SUBDOMAIN_INSTALL)
+          if [[ "${SUBDOMAIN_INSTALL}" != "1" ]]; then
+            # SUBDOMAIN_INSTALL should be true.
+              echo -e "${RED}Subdomain configuration not found!${RESET}"
+              exit 1
+          fi
+          # Wait for the git push to finish.
+          terminus workflow:wait "${{ env.SITE_ID }}".dev
       - name: Run Playwright tests
         env:
           SITE_NAME: ${{ env.SITE_NAME }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -447,9 +447,11 @@ jobs:
         env:
           SITE_NAME: ${{ env.SITE_NAME }}
           SITE_URL: ${{ env.SITE_URL }}
+          GRAPHQL_ENDPOINT: ${{ env.SITE_URL }}/wp/graphql
         run: npm run test .github/tests/wpcm.spec.ts
       - name: Run Playwright tests on subdomain site
         env:
           SITE_NAME: Foo
           SITE_URL: ${{ env.SUBDOMAIN_URL }}
+          GRAPHQL_ENDPOINT: ${{ env.SUBDOMAIN_URL }}/wp/graphql
         run: npm run test .github/tests/wpcm.spec.ts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -417,6 +417,10 @@ jobs:
 
           echo "Copying latest changes and committing to the site."
           rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" "${{ github.workspace }}/" .
+
+          echo "Installing wp-graphql..."
+          composer require wp-graphql/wp-graphql
+
           git add -A
           git commit -m "Update to latest commit: ${{ env.COMMIT_MSG }}" || true
           git push origin master || true
@@ -426,6 +430,9 @@ jobs:
 
           echo "Checking WordPress install status"
           terminus wp "${{ env.SITE_ID }}".dev -- cli info
+
+          # Activte WP-GraphQL plugin
+          terminus wp "${{ env.SITE_ID }}".dev -- plugin activate wp-graphql
 
           # Run curl checks against the site URLs to ensure the main site and the subdomain site exist.
           echo "Checking site URLs"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -399,6 +399,18 @@ jobs:
           echo "Clone the site locally and copy PR updates"
           terminus local:clone ${{ env.SITE_ID }}
           cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"
+
+          if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true MULTISITE; then
+            echo "Multisite not configured yet..."
+            echo "Copying multisite application.php"
+            rm ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
+            cp "${{ github.workspace }}/.github/fixtures/config/application.subdom.php" ~/pantheon-local-copies/${{ env.SITE_ID }}/config/
+            mv ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.${type}.php" ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
+            cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"
+            git add ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
+            git commit -m "Set up ${type} multisite config" || true
+          fi
+
           echo "Copying latest changes and committing to the site."
           rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" "${{ github.workspace }}/" .
           git add -A

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -417,15 +417,21 @@ jobs:
 
           echo "Copying latest changes and committing to the site."
           rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" "${{ github.workspace }}/" .
+          git add -A
+          git commit -m "Update to latest commit: ${{ env.COMMIT_MSG }}" || true
 
           echo "Installing wp-graphql..."
           composer require wp-graphql/wp-graphql
+          git add composer.json composer.lock
+          git commit -m "Add WP-GraphQL plugin" || true
 
-          git add -A
-          git commit -m "Update to latest commit: ${{ env.COMMIT_MSG }}" || true
+          echo "Copying the subdomain multisite config/application.php file..."
+          cp -f "${{ github.workspace }}/.github/fixtures/config/application.subdom.php" config/application.php
+          git add config/application.php
+          git commit -m "Add subdomain multisite config" || true
+
+          # Push and wait for the git push to finish.
           git push origin master || true
-
-          # Wait for the git push to finish.
           terminus workflow:wait "${{ env.SITE_ID }}".dev
 
           echo "Checking WordPress install status"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -415,17 +415,6 @@ jobs:
           terminus local:clone ${{ env.SITE_ID }}
           cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"
 
-          if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true MULTISITE; then
-            echo "Multisite not configured yet..."
-            echo "Copying multisite application.php"
-            rm ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
-            cp "${{ github.workspace }}/.github/fixtures/config/application.subdom.php" ~/pantheon-local-copies/${{ env.SITE_ID }}/config/
-            mv ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.subdom.php ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
-            cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"
-            git add ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
-            git commit -m "Set up subdomain multisite config" || true
-          fi
-
           echo "Copying latest changes and committing to the site."
           rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" "${{ github.workspace }}/" .
           git add -A
@@ -437,14 +426,14 @@ jobs:
 
           echo "Checking WordPress install status"
           terminus wp "${{ env.SITE_ID }}".dev -- cli info
-          if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true MULTISITE; then
-            echo -e "Multisite not found!"
+
+          # Run curl checks against the site URLs to ensure the main site and the subdomain site exist.
+          echo "Checking site URLs"
+          SITE_URL_TEST=$(curl -s -o /dev/null -w "%{http_code}" ${{ env.SITE_URL }})
+          SUBDOMAIN_URL_TEST=$(curl -s -o /dev/null -w "%{http_code}" ${{ env.SUBDOMAIN_URL }})
+          if [ $SITE_URL_TEST -ne 200 ] || [ $SUBDOMAIN_URL_TEST -ne 200 ]; then
+            echo "One or more site URLs are not returning a 200 status code. Exiting."
             exit 1
-          fi
-          # Check SUBDOMAIN_INSTALL value
-          if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true SUBDOMAIN_INSTALL; then
-              echo -e "Subdomain configuration not found!"
-              exit 1
           fi
       - name: Run Playwright tests
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -405,10 +405,10 @@ jobs:
             echo "Copying multisite application.php"
             rm ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
             cp "${{ github.workspace }}/.github/fixtures/config/application.subdom.php" ~/pantheon-local-copies/${{ env.SITE_ID }}/config/
-            mv ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.${type}.php" ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
+            mv ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.subdom.php ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
             cd ~/pantheon-local-copies/"${{ env.SITE_ID }}"
             git add ~/pantheon-local-copies/${{ env.SITE_ID }}/config/application.php
-            git commit -m "Set up ${type} multisite config" || true
+            git commit -m "Set up subdomain multisite config" || true
           fi
 
           echo "Copying latest changes and committing to the site."

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -432,6 +432,9 @@ jobs:
           git commit -m "Update to latest commit: ${{ env.COMMIT_MSG }}" || true
           git push origin master || true
 
+          # Wait for the git push to finish.
+          terminus workflow:wait "${{ env.SITE_ID }}".dev
+
           echo "Checking WordPress install status"
           terminus wp "${{ env.SITE_ID }}".dev -- cli info
           if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true MULTISITE; then
@@ -443,8 +446,6 @@ jobs:
               echo -e "Subdomain configuration not found!"
               exit 1
           fi
-          # Wait for the git push to finish.
-          terminus workflow:wait "${{ env.SITE_ID }}".dev
       - name: Run Playwright tests
         env:
           SITE_NAME: ${{ env.SITE_NAME }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -433,6 +433,7 @@ jobs:
 
           # Activte WP-GraphQL plugin
           terminus wp "${{ env.SITE_ID }}".dev -- plugin activate wp-graphql
+          terminus env:clear-cache "${{ env.SITE_ID }}".dev
 
           # Run curl checks against the site URLs to ensure the main site and the subdomain site exist.
           echo "Checking site URLs"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,6 +1,21 @@
 name: WordPress Composer Playwright Tests
 on:
   pull_request:
+    paths-ignore:
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/composer-diff.yml'
+      - '.github/workflows/phpcbf.yml'
+      - '.github/workflows/sage-test.yml'
+      - '.github/workflows/sync-default.yml'
+      - '.github/tests/*.bats'
+      - 'private/scripts/**'
+      - 'docs/**'
+      - '*.md'
+      - 'phpcs.yml'
+      - 'wp-cli.yml'
+      - '.lando.upstream.yml'
+      - 'CODEOWNERS'
+      - '.editorconfig'
     types:
       - opened
       - reopened

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -447,6 +447,8 @@ jobs:
           SUBDOMAIN_URL_TEST=$(curl -s -o /dev/null -w "%{http_code}" ${{ env.SUBDOMAIN_URL }})
           if [ $SITE_URL_TEST -ne 200 ] || [ $SUBDOMAIN_URL_TEST -ne 200 ]; then
             echo "One or more site URLs are not returning a 200 status code. Exiting."
+            echo "${{ env.SITE_URL }} - ${SITE_URL_TEST}"
+            echo "${{ env.SUBDOMAIN_URL }} - ${SUBDOMAIN_URL_TEST}"
             exit 1
           fi
       - name: Run Playwright tests on main site

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -443,13 +443,13 @@ jobs:
             echo "One or more site URLs are not returning a 200 status code. Exiting."
             exit 1
           fi
-      - name: Run Playwright tests
+      - name: Run Playwright tests on main site
         env:
           SITE_NAME: ${{ env.SITE_NAME }}
           SITE_URL: ${{ env.SITE_URL }}
-        run: |
-          npm run test .github/tests/wpcm.spec.ts
-          SITE_NAME=Foo
-          SITE_URL=${{ env.SUBDOMAIN_URL }}
-          echo "Running Playwright tests on WordPress Subdomain subsite"
-            npm run test .github/tests/wpcm.spec.ts
+        run: npm run test .github/tests/wpcm.spec.ts
+      - name: Run Playwright tests on subdomain site
+        env:
+          SITE_NAME: Foo
+          SITE_URL: ${{ env.SUBDOMAIN_URL }}
+        run: npm run test .github/tests/wpcm.spec.ts

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -408,14 +408,14 @@ jobs:
           echo "Checking WordPress install status"
           terminus wp "${{ env.SITE_ID }}".dev -- cli info
           if ! terminus wp "${{ env.SITE_ID }}".dev -- config is-true MULTISITE; then
-            echo -e "${RED}Multisite not found!${RESET}"
+            echo -e "Multisite not found!"
             exit 1
           fi
           # Check SUBDOMAIN_INSTALL value
           SUBDOMAIN_INSTALL=$(terminus wp "${{ env.SITE_ID }}".dev -- config get SUBDOMAIN_INSTALL)
           if [[ "${SUBDOMAIN_INSTALL}" != "1" ]]; then
             # SUBDOMAIN_INSTALL should be true.
-              echo -e "${RED}Subdomain configuration not found!${RESET}"
+              echo -e "Subdomain configuration not found!"
               exit 1
           fi
           # Wait for the git push to finish.

--- a/devops/scripts/setup-playwright-tests.sh
+++ b/devops/scripts/setup-playwright-tests.sh
@@ -70,7 +70,7 @@ copy_pr_updates() {
   echo "Commit Message: ${commit_msg}"
   cd ~/pantheon-local-copies/"${site_id}"
   echo -e "${YELLOW}Copying latest changes and committing to the site.${RESET}"
-  rsync -a --exclude='.git' --exclude='status-*.txt' "${workspace}/" .
+  rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" ${workspace}/" .
   git add -A
   git commit -m "Update to latest commit: ${commit_msg}" || true
   git push origin master || true

--- a/devops/scripts/setup-playwright-tests.sh
+++ b/devops/scripts/setup-playwright-tests.sh
@@ -70,7 +70,7 @@ copy_pr_updates() {
   echo "Commit Message: ${commit_msg}"
   cd ~/pantheon-local-copies/"${site_id}"
   echo -e "${YELLOW}Copying latest changes and committing to the site.${RESET}"
-  rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" ${workspace}/" .
+  rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" "${workspace}/" .
   git add -A
   git commit -m "Update to latest commit: ${commit_msg}" || true
   git push origin master || true

--- a/devops/scripts/setup-playwright-tests.sh
+++ b/devops/scripts/setup-playwright-tests.sh
@@ -70,7 +70,7 @@ copy_pr_updates() {
   echo "Commit Message: ${commit_msg}"
   cd ~/pantheon-local-copies/"${site_id}"
   echo -e "${YELLOW}Copying latest changes and committing to the site.${RESET}"
-  rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" "${workspace}/" .
+  rsync -a --exclude='.git' --exclude='status-*.txt' --exclude="node_modules" ${workspace}/" .
   git add -A
   git commit -m "Update to latest commit: ${commit_msg}" || true
   git push origin master || true


### PR DESCRIPTION
We're not running the full setup-playwright-tests script because subdomain multisites don't need most of the setup. However, it does need _some_ of the setup (specifically copying the changes from the PR to the fixture site), so we need to manually add those back into that workflow.

In the future we might be able to run just portions of the script for the purpose of subdomain multisite so we're not duplicating code here.

~This PR is blocked by #147 -- the changes the robot fixed were part of what was updated in that PR. Merging this PR before that one will create a commit that gets dropped during deploy.~

This change includes some tweaks to the actual playwright tests and some deviations in the setup. It was discovered in running the tests that the subdomain fixture site was getting reset (GraphQL plugin being deleted, multisite config resetting) -- those have been added to the setup -- but in troubleshooting those it was hypothesized that an incorrect GraphQL endpoint url _could have been_ the issue (it wasn't, multisite not being set up was the issue), or that the environment variables weren't being processed correctly (that wasn't it either, but that was only discovered after breaking the Playwright tests into separate tests -- one for the main site and one for the subdomain). An additional passed environment variable is now supported, however, for GraphQL endpoint, which means that we can eventually remove the handling in the test for different endpoint urls for _subdirectory_ multisite (not included in this PR as it doesn't relate to the subdomain testing).