### PR TITLE
Move cookie settings inside the pantheon environment check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ WP_ENV='development'
 DB_NAME=$_ENV['DB_NAME']
 DB_USER=$_ENV['DB_USER']
 DB_PASSWORD=$_ENV['DB_PASSWORD']
+DB_HOST=$_ENV['DB_HOST']:$_ENV['DB_PORT']
 
 # Optional database variables
 # DB_HOST='localhost'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### v1.32.0 (2024-08-15)
+
 ### v1.31.1 (2024-07-29)
 * Removes code that for handling wp-admin URLs. ([#143](https://github.com/pantheon-systems/wordpress-composer-managed/pull/143)) This code was not working as intended and testing revealed it to be unnecessary.
 * Adds a filter to disable the subdirectory multisite custom wp-content directory warning. ([#144](https://github.com/pantheon-systems/wordpress-composer-managed/pull/144)) This implements the filter added in the [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) in [#51](https://github.com/pantheon-systems/pantheon-mu-plugin/pull/51).

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -79,10 +79,11 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		$hostname = isset( $_ENV['LANDO'] ) ? "{$site_name}.lndo.site" : $hostname;
 		define( 'PANTHEON_HOSTNAME', $hostname );
 	}
+
+    // Cookie settings.
+    defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', PANTHEON_HOSTNAME );
+    defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
+    defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
+    defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );
 }
 
-// Cookie settings.
-defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', PANTHEON_HOSTNAME );
-defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
-defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
-defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -80,10 +80,9 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 		define( 'PANTHEON_HOSTNAME', $hostname );
 	}
 
-    // Cookie settings.
-    defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', PANTHEON_HOSTNAME );
-    defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
-    defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
-    defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );
+	// Cookie settings.
+	defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', PANTHEON_HOSTNAME );
+	defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
+	defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
+	defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );
 }
-


### PR DESCRIPTION
The cookie domain now uses `pantheon_hostname`, which is only defined if we're on a pantheon environment.

This pull request also re-adds the `DB_HOST` line in `.env.example`. This line was removed in the rebase. Both of these files are release files, so this should push to the upstream.