### PR TITLE
Handle merge commits with multiple parents and conflicts

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/sync-default.yml'
       - '.github/tests/*.bats'
       - 'private/scripts/**'
+      - 'devops/**'
       - 'docs/**'
       - '*.md'
       - 'phpcs.yml'

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -79,9 +79,7 @@ for commit in "${commits[@]}"; do
 
     # Stage the changes and continue the cherry-pick
     git add -u
-    git commit --no-edit || {
-      echo "No changes to commit. Continuing."
-    }
+    git commit --no-edit || echo "No changes to commit. Continuing."
   fi
   # Product request - single commit per release
   # The commit message from the last commit will be used.

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -68,7 +68,26 @@ for commit in "${commits[@]}"; do
   fi
   echo "Adding $commit:"
   git --no-pager log --format=%B -n 1 "$commit"
-  git cherry-pick -rn -X theirs -m 1 "$commit" 2>&1
+  if ! git cherry-pick -rn -X theirs -m 1 "$commit"; then
+    echo "Conflict detected in $commit. Checking for deleted files."
+    conflicted_files=$(git diff --name-only --diff-filter=U)
+    for file in $conflicted_files; do
+      if git show "$commit" -- "$file" | grep -q 'delete mode'; then
+        echo "File $file was deleted in the cherry-picked commit. Resolving by keeping the deletion."
+        git rm "$file"
+      else
+        echo "Resolving conflict for $file with 'theirs'."
+        git checkout --theirs -- "$file"
+        git add "$file"
+      fi
+    done
+
+    # Stage the changes and continue the cherry-pick
+    git add -u
+    git commit --no-edit || {
+      echo "No changes to commit. Continuing."
+    }
+  fi
   # Product request - single commit per release
   # The commit message from the last commit will be used.
   git log --format=%B -n 1 "$commit" > /tmp/commit_message

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -93,6 +93,7 @@ rm ./README.md
 cp /tmp/composer-managed-README.md ./README.md
 
 # Create a list of files that we need to exclude from the commit.
+# These are files that may be coming from Roots or old commits that do not exist in the source and _should not exist_ on the upstream.
 ignored_files="composer.lock CODE_OF_CONDUCT.md CONTRIBUTING.md"
 
 # Remove ignored files from the commit.

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -2,9 +2,6 @@
 # This script is pretty tailored to assuming it's running in the CircleCI environment / a fresh git clone.
 # It mirrors most commits from `pantheon-systems/wordpress-composer-managed:release` to `pantheon-upstreams/wordpress-composer-managed`.
 
-UPSTREAM_REPO_REMOTE_URL=git@github.com:jazzsequence/wordpress-composer-managed.git
-CIRCLE_BRANCH="handle-complex-deploys"
-
 # Check github authentication; ignore status code 1 returned from this command
 ssh -T git@github.com
 
@@ -57,10 +54,10 @@ fi
 git checkout -b public --track public/main
 git pull
 
-# if [[ "$CIRCLECI" != "" ]]; then
-#   git config --global user.email "bot@getpantheon.com"
-#   git config --global user.name "Pantheon Automation"
-# fi
+if [[ "$CIRCLECI" != "" ]]; then
+  git config --global user.email "bot@getpantheon.com"
+  git config --global user.name "Pantheon Automation"
+fi
 
 for commit in "${commits[@]}"; do
   if [[ -z "$commit" ]] ; then
@@ -109,8 +106,8 @@ git push public public:main
 
 git checkout "$CIRCLE_BRANCH"
 
-# # update the release-pointer
-# git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD
+# update the release-pointer
+git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD
 
-# # Push release-pointer
-# git push -f origin release-pointer
+# Push release-pointer
+git push -f origin release-pointer

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -72,7 +72,7 @@ for commit in "${commits[@]}"; do
     echo "Conflict detected in $commit. Checking for deleted files."
     conflicted_files=$(git diff --name-only --diff-filter=U)
     for file in $conflicted_files; do
-      if git show "$commit" -- "$file" | grep -q 'delete mode'; then
+      if git diff "$commit"^.."$commit" -- "$file" | grep -q 'delete mode'; then
         echo "File $file was deleted in the cherry-picked commit. Resolving by keeping the deletion."
         git rm "$file"
       else

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -92,6 +92,12 @@ echo "Copying README to docroot."
 rm ./README.md
 cp /tmp/composer-managed-README.md ./README.md
 
+# Check for composer.lock. If it exists, delete it. Composer lock files should never be in the upstream. See: https://github.com/pantheon-systems/wordpress-composer-managed/blob/main/README-internal.md#preventing-composerlock-from-being-committed
+if [ -f composer.lock ]; then
+  echo "Deleting composer.lock"
+  rm composer.lock
+fi
+
 git add .
 
 echo "Committing changes"

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -72,13 +72,11 @@ for commit in "${commits[@]}"; do
     echo "Conflict detected in $commit. Checking for deleted files."
     conflicted_files=$(git diff --name-only --diff-filter=U)
     for file in $conflicted_files; do
-      if git diff "$commit"^.."$commit" -- "$file" | grep -q 'delete mode'; then
+      if ! git ls-tree -r "$commit" --name-only | grep -q "^$file$"; then
         echo "File $file was deleted in the cherry-picked commit. Resolving by keeping the deletion."
         git rm "$file"
       else
-        echo "Resolving conflict for $file with 'theirs'."
-        git checkout --theirs -- "$file"
-        git add "$file"
+        echo "Conflict required manual resolution for $file."
       fi
     done
 

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -98,6 +98,16 @@ if [ -f composer.lock ]; then
   rm composer.lock
 fi
 
+# Check for Roots-specific community files.
+if [ -f CODE_OF_CONDUCT.md ]; then
+  echo "Deleting CODE_OF_CONDUCT.md"
+  rm CODE_OF_CONDUCT.md
+fi
+if [ -f CONTRIBUTING.md ]; then
+  echo "Deleting CONTRIBUTING.md"
+  rm CONTRIBUTING.md
+fi
+
 git add .
 
 echo "Committing changes"

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -92,21 +92,16 @@ echo "Copying README to docroot."
 rm ./README.md
 cp /tmp/composer-managed-README.md ./README.md
 
-# Check for composer.lock. If it exists, delete it. Composer lock files should never be in the upstream. See: https://github.com/pantheon-systems/wordpress-composer-managed/blob/main/README-internal.md#preventing-composerlock-from-being-committed
-if [ -f composer.lock ]; then
-  echo "Deleting composer.lock"
-  rm composer.lock
-fi
+# Create a list of files that we need to exclude from the commit.
+ignored_files="composer.lock CODE_OF_CONDUCT.md CONTRIBUTING.md"
 
-# Check for Roots-specific community files.
-if [ -f CODE_OF_CONDUCT.md ]; then
-  echo "Deleting CODE_OF_CONDUCT.md"
-  rm CODE_OF_CONDUCT.md
-fi
-if [ -f CONTRIBUTING.md ]; then
-  echo "Deleting CONTRIBUTING.md"
-  rm CONTRIBUTING.md
-fi
+# Remove ignored files from the commit.
+for file in $ignored_files; do
+  if [ -f "$file" ]; then
+    echo "Removing $file from the commit."
+    git rm "$file"
+  fi
+done
 
 git add .
 

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -2,6 +2,9 @@
 # This script is pretty tailored to assuming it's running in the CircleCI environment / a fresh git clone.
 # It mirrors most commits from `pantheon-systems/wordpress-composer-managed:release` to `pantheon-upstreams/wordpress-composer-managed`.
 
+UPSTREAM_REPO_REMOTE_URL=git@github.com:jazzsequence/wordpress-composer-managed.git
+CIRCLE_BRANCH="handle-complex-deploys"
+
 # Check github authentication; ignore status code 1 returned from this command
 ssh -T git@github.com
 
@@ -54,10 +57,10 @@ fi
 git checkout -b public --track public/main
 git pull
 
-if [[ "$CIRCLECI" != "" ]]; then
-  git config --global user.email "bot@getpantheon.com"
-  git config --global user.name "Pantheon Automation"
-fi
+# if [[ "$CIRCLECI" != "" ]]; then
+#   git config --global user.email "bot@getpantheon.com"
+#   git config --global user.name "Pantheon Automation"
+# fi
 
 for commit in "${commits[@]}"; do
   if [[ -z "$commit" ]] ; then
@@ -89,8 +92,8 @@ git push public public:main
 
 git checkout "$CIRCLE_BRANCH"
 
-# update the release-pointer
-git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD
+# # update the release-pointer
+# git tag -f -m 'Last commit set on upstream repo' release-pointer HEAD
 
-# Push release-pointer
-git push -f origin release-pointer
+# # Push release-pointer
+# git push -f origin release-pointer

--- a/devops/scripts/deploy-public-upstream.sh
+++ b/devops/scripts/deploy-public-upstream.sh
@@ -65,7 +65,7 @@ for commit in "${commits[@]}"; do
   fi
   echo "Adding $commit:"
   git --no-pager log --format=%B -n 1 "$commit"
-  git cherry-pick -rn -X theirs "$commit" 2>&1
+  git cherry-pick -rn -X theirs -m 1 "$commit" 2>&1
   # Product request - single commit per release
   # The commit message from the last commit will be used.
   git log --format=%B -n 1 "$commit" > /tmp/commit_message


### PR DESCRIPTION
This pull request adds handling for merge commits with multiple parents and conflicts where the cherry-picked commit delets a file that does not exist in the `--theirs` version.

Test deploy is here: https://github.com/pantheon-upstreams/wordpress-composer-managed/compare/main...jazzsequence:wordpress-composer-managed:main

https://github.com/pantheon-systems/wordpress-composer-managed/pull/152/commits/78e48620916e213fe0a4c57698de764871d49130 was added because it looks like the `composer.lock` was being added in that deploy https://github.com/jazzsequence/wordpress-composer-managed