### PR TITLE
[SITE-1585] WordPress (Composer Managed) 1.32.0 Release PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### v1.32.0 (2024-08-15)
+### v1.32.0 (2024-08-06)
+* This update primarily fixes consistency issues between the development repository ([`pantheon-systems/wordpress-composer-managed`](https://github.com/pantheon-systems/wordpress-composer-managed)) and the upstream repository ([`pantheon-upstreams/wordpress-composer-managed`](https://github.com/pantheon-upstreams/wordpress-composer-managed)). Most notably, this update removes decoupled packages that were erroneously being added to the non-decoupled upstream (and are not included in this repository).
+* Fixes issues with subdomain multisite testing ([#148](https://github.com/pantheon-systems/wordpress-composer-managed/pull/148))
+* Updates automation steps to check PRs for "mixed" commits ([#146](https://github.com/pantheon-systems/wordpress-composer-managed/pull/146)) and adds handling for merge commits and conflicts ([#152](https://github.com/pantheon-systems/wordpress-composer-managed/pull/152))
+* Moves cookie settings inside the pantheon environment check ([#151](https://github.com/pantheon-systems/wordpress-composer-managed/pull/151))
 
 ### v1.31.1 (2024-07-29)
 * Removes code that for handling wp-admin URLs. ([#143](https://github.com/pantheon-systems/wordpress-composer-managed/pull/143)) This code was not working as intended and testing revealed it to be unnecessary.


### PR DESCRIPTION
When merged, this will push updates in:

- #146
- #147
- #148
- #149
- #151
- #152

...as well as a manual rebase on `pantheon-upstreams/wordpress-composer-managed` to resolve the inconsistencies noted in the changelog update and the [release note](https://github.com/pantheon-systems/documentation/pull/9147)

Dashboard commit message:
```
Resolves inconsistency issues between WordPress (Composer Managed) development repository and the upstream repository.
Additional minor updates and fixes included in this update. For more information see https://docs.pantheon.io/release-notes/2024/08/wordpress-composer-managed-1-32-0
```