### PR TITLE
apply merge conflict handling to decoupled workflow

### DIFF
--- a/devops/scripts/deploy-decoupled-upstream.sh
+++ b/devops/scripts/deploy-decoupled-upstream.sh
@@ -94,11 +94,25 @@ for commit in "${commits[@]}"; do
   fi
   echo "Adding $commit:"
   git --no-pager log --format=%B -n 1 "$commit"
-  git cherry-pick -rn -X theirs "$commit" 2>&1
+  if ! git cherry-pick -rn -X theirs -m 1 "$commit"; then
+    echo "Conflict detected in $commit. Checking for deleted files."
+    conflicted_files=$(git diff --name-only --diff-filter=U)
+    for file in $conflicted_files; do
+      if ! git ls-tree -r "$commit" --name-only | grep -q "^$file$"; then
+        echo "File $file was deleted in the cherry-picked commit. Resolving by keeping the deletion."
+        git rm "$file"
+      else
+        echo "Conflict required manual resolution for $file."
+      fi
+    done
+
+    # Stage the changes and continue the cherry-pick
+    git add -u
+    git commit --no-edit || echo "No changes to commit. Continuing."
+  fi
   # Product request - single commit per release
   # The commit message from the last commit will be used.
   git log --format=%B -n 1 "$commit" > /tmp/commit_message
-  # git commit --amend --no-edit --author='Pantheon Automation <bot@getpantheon.com>'
 done
 
 echo "Executing decoupledpatch.sh"


### PR DESCRIPTION
This PR copies the merge conflict handling in the main `deploy-public-upstream` script to the decoupled version. This should probably be abstracted out so we only have one script and the differences are passed in via parameters.