### PR TITLE
add is_multisite check to str_replace

### DIFF
--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -162,7 +162,7 @@ function adjust_main_site_urls( string $url ) : string {
 	}
 
 	// If this is the main site, drop the /wp.
-	if ( is_main_site() ) {
+	if ( is_main_site() && is_multisite() ) {
 		$url = str_replace( '/wp/', '/', $url );
 	}
 


### PR DESCRIPTION
Fixes an issue with the last update that does not fully fix the broken paths for some core resources on some sites (single site and subdirectory multisite).

This PR adds an `is_multisite` check back into the filters that handle the url rewriting.

This was discovered on a one-off test site of mine and confirmed by a customer using the WPCM upstream (and a custom upstream based off it). Confirmed working in both cases and it was confirmed that this issue does not exist on subdomain multisite and subdomain multisite continues to be unaffected by the change.

tested on subdom, subdir and single sites