### PR TITLE
Release 1.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.32.2 (2024-09-03)
+* Fixes a bug in the previous update where some WordPress core resources were not available on some single and subdirectory multisite installs. ([161](https://github.com/pantheon-systems/wordpress-composer-managed/pull/161))
+
 ### v1.32.1 (2024-08-16)
 * Refactors core resource URL filtering and multisite handling. ([#157](https://github.com/pantheon-systems/wordpress-composer-managed/pull/157)) This resolves an issue where some WordPress core resources were 404ing on single site installs.
 


### PR DESCRIPTION
Updates changelog for 1.32.2.

Changes in this release:
* #161

Dashboard message
```
Resolves a bug in the last update to fix WordPress core resource paths.

For more information, see https://docs.pantheon.io/release-notes/2024/08/wordpress-composer-managed-1-32-2
```