### PR TITLE
Restore original copyright

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,4 @@
+Copyright (c) Roots Software Foundation LLC
 Copyright (c) Pantheon Systems
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
The @roots copyright was removed in [commit 421c09a](https://github.com/pantheon-systems/wordpress-composer-managed/commit/421c09a3420dffa764b68ca2e4f34e1ebff08e36), which violates the terms of the MIT license. The MIT license requires that the original copyright notice be retained in all copies of the software.