### PR TITLE
[BUGS-8840] Fix cookie paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.32.3 (2024-09-10)
+* Updates `COOKIEPATH` and `SITECOOKIEPATH` values to `/` in `application.pantheon.php` to resolve cookie-related nonce authentication failures. Previously, the values were set to `''` (empty string), which does not allow the cookies to allow authentication within all the paths in a domain. ([#]())
+
 ### v1.32.2 (2024-09-03)
 * Fixes a bug in the previous update where some WordPress core resources were not available on some single and subdirectory multisite installs. ([161](https://github.com/pantheon-systems/wordpress-composer-managed/pull/161))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### v1.32.3 (2024-09-10)
-* Updates `COOKIEPATH` and `SITECOOKIEPATH` values to `/` in `application.pantheon.php` to resolve cookie-related nonce authentication failures. Previously, the values were set to `''` (empty string), which does not allow the cookies to allow authentication within all the paths in a domain. ([#]())
+* Updates `COOKIEPATH` and `SITECOOKIEPATH` values to `/` in `application.pantheon.php` to resolve cookie-related nonce authentication failures. Previously, the values were set to `''` (empty string), which does not allow the cookies to allow authentication within all the paths in a domain. ([#164](https://github.com/pantheon-systems/wordpress-composer-managed/pull/164))
 
 ### v1.32.2 (2024-09-03)
 * Fixes a bug in the previous update where some WordPress core resources were not available on some single and subdirectory multisite installs. ([161](https://github.com/pantheon-systems/wordpress-composer-managed/pull/161))

--- a/config/application.pantheon.php
+++ b/config/application.pantheon.php
@@ -83,6 +83,6 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	// Cookie settings.
 	defined( 'COOKIE_DOMAIN' ) or Config::define( 'COOKIE_DOMAIN', PANTHEON_HOSTNAME );
 	defined( 'ADMIN_COOKIE_PATH' ) or Config::define( 'ADMIN_COOKIE_PATH', '/' );
-	defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '' );
-	defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '' );
+	defined( 'COOKIEPATH' ) or Config::define( 'COOKIEPATH', '/' );
+	defined( 'SITECOOKIEPATH' ) or Config::define( 'SITECOOKIEPATH', '/' );
 }


### PR DESCRIPTION
This PR fixes the cookie paths in the `application.pantheon.php`. Previously, the empty string prevented cookies from being valid within domains causing nonce authentication failures.

Note: this was erroneously pushed directly to `release` so this already exists in the upstream.