### PR TITLE
[SITE-3578] Fix missing index php

### DIFF
--- a/.github/tests/1-test-update-php.bats
+++ b/.github/tests/1-test-update-php.bats
@@ -76,3 +76,11 @@ teardown() {
   run grep -q "php_version: 8.3" pantheon.yml
   [ "$status" -eq 0 ]
 }
+
+@test "Test missing index.php" {
+  # Remove web/index.php.
+  rm web/index.php
+  bash ./private/scripts/helpers.sh maybe_create_symlinks >> /dev/null
+  run cat web/index.php
+  [ "$status" -eq 0 ]
+}

--- a/private/scripts/helpers.sh
+++ b/private/scripts/helpers.sh
@@ -183,6 +183,28 @@ function get_info() {
   sagedir=$themedir/$sagename
 }
 
+# Create the web/index.php if it does not exist.
+function check_index_php() {
+  # Check if we are in the web directory
+  if [ "${PWD##*/}" != "web" ]; then
+    echo "${red}Error: You must be in the 'web' directory to run this script.${normal}"
+    exit 1
+  fi
+  # Check if index.php exists, create if it doesn't
+  if [ ! -f "index.php" ]; then
+    echo "${yellow}Creating index.php...${normal}"
+    cat > index.php << 'EOF'
+<?php
+/**
+ * WordPress View Bootstrapper
+ */
+define('WP_USE_THEMES', true);
+require __DIR__ . '/wp/wp-blog-header.php';
+EOF
+    echo "${green}Created index.php${normal}"
+  fi
+}
+
 # Confirm user-submitted theme-name and ensure letters are lower-space
 function confirmThemeName() {
   # Replace spaces with dashes and convert to lowercase
@@ -554,6 +576,8 @@ function maybe_create_symlinks() {
   done
   printf "\e[D✅\e[C"
   echo ""
+
+  check_index_php
   echo "${green}Done creating symlinks!${normal} 🔗"
 }
 


### PR DESCRIPTION
In some cases, we have gotten reports that the `web/index.php` goes missing. When this happens, it breaks the site because we also ignore `web/index.php` in the `.gitignore` file.

I have not been able to reproduce the circumstances that make this happen, however, if I manually delete `web/index.php`, it does, indeed, break the site irreparably (since we point to `/wp/wp-blog-header.php` instead of just `/wp-blog-header.php`).

We could solve the issue by removing the line in the `.gitignore` file but as it doesn't seem to be having this effect normally, and because that would potentially break anyone who has customized their `.gitignore`, this is not desirable.

Instead, this PR adds a check for `web/index.php` when we're checking if we need to, and creating symlinks to files in the `/wp` directory and are already in the `/web` directory. If `index.php` does not already exist, the additional function creates the file.

A BATS tests has been added to validate the behavior.