### PR TITLE
[SITE-3292] add @maybe-add-symlinks to post-update-cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-### v1.32.4
+### v1.32.5 (2025-02-10)
+* Adds the `maybe-install-symlinks` Composer script to `post-update-cmd` hook. This ensures that symlinks are created (and the `web/index.php` file is re-created) after a `composer update`. ([#175](https://github.com/pantheon-systems/wordpress-composer-managed/pull/175))
+
+### v1.32.4 (2025-02-10)
 * Adds a check for `web/index.php` and re-creates the file if it does not exist. Resolves issues where `web/index.php` is missing and breaks a site. ([#173](https://github.com/pantheon-systems/wordpress-composer-managed/pull/173))
 
 ### v1.32.3 (2024-09-10)

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -108,6 +108,13 @@ class ComposerScripts
             }
         }
 
+        $maybe_add_symlinks = '@maybe-add-symlinks';
+        // Check if @maybe-add-symlinks is already in post-update-cmd. If not, add it.
+        if (!in_array($maybe_add_symlinks, $composerJson['scripts']['post-update-cmd'])) {
+            $io->write("<info>Adding $maybe_add_symlinks to post-update-cmd hook</info>");
+            $composerJson['scripts']['post-update-cmd'][] = $maybe_add_symlinks;
+        }
+
         if (serialize($composerJson) == serialize($originalComposerJson)) {
             return;
         }


### PR DESCRIPTION
Add the symlinks if they don't already exist.

When applying the upstream updates from 1.32.4, it was discovered that the symlinks to `wp-*` files (and the `index.php` file creation) is not run leaving the site in an empty state. When cache expires, the site will be broken with the files missing. (Perhaps this was the issue all along?)

This uses the existing `ComposerScripts` class and `preUpdate` hook (hooked to the composer `pre-update-cmd`) to update the `composer.json` to add `@maybe-install-symlinks` if that's not already part of the `post-update-cmd`. The `post-update-cmd` is also created by this script (if it did not exist already), so this change checks for the existance of the script we're adding and adds it if it's not there, which is then run after the `composer update` is executed.