### PR TITLE
set service level to pro on site creation for playwright tests

### DIFF
--- a/devops/scripts/setup-playwright-tests.sh
+++ b/devops/scripts/setup-playwright-tests.sh
@@ -39,6 +39,8 @@ create_site() {
     echo "Test site already exists, skipping site creation."
   else
     terminus site:create "${site_id}" "${site_name}" "${UPSTREAM_NAME}" --org=5ae1fa30-8cc4-4894-8ca9-d50628dcba17
+    echo "Site created. Setting site plan to 'pro'"
+    terminus service-level:set "${site_id}" pro
   fi
   terminus connection:set "${site_id}".dev git -y
 }


### PR DESCRIPTION
fixes #176

Sets the site plan to `pro` on site creation.

This applies to subdir and single site fixture sites. the subdomain fixture site is a standing site (which has already had its service level set to `pro`).

No release necessary for this change as it is CI only.