### PR TITLE
[DEVREL-29] Adds testing for new URL handling for API endpoints when "pretty permalinks" aren't set

### DIFF
--- a/.github/tests/2-rest-url-fix.bats
+++ b/.github/tests/2-rest-url-fix.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+# wp wrapper function
+_wp() {
+  terminus wp -- ${SITE_ID}.dev "$@"
+}
+
+# Helper function to get REST URL via WP-CLI
+get_rest_url() {
+  _wp eval 'echo get_rest_url();'
+}
+
+# Helper function to get home_url path via WP-CLI
+get_home_url_path() {
+  _wp eval 'echo rtrim(parse_url(home_url(), PHP_URL_PATH) ?: "", "/");'
+}
+
+setup_suite() {
+  # Ensure WP is installed and we are in the right directory
+  _wp core is-installed || (echo "WordPress not installed. Run setup script first." && exit 1)
+}
+
+@test "Check REST URL with default (pretty) permalinks (after setup script flush)" {
+  run get_rest_url
+  assert_success
+  # Default setup script sets /%postname%/ and flushes.
+  # Expecting /wp/wp-json/ because home_url path should be /wp
+  assert_output --partial "/wp/wp-json/"
+}
+
+@test "Check REST URL with plain permalinks" {
+  # Set plain permalinks and flush
+  _wp option update permalink_structure '' --quiet
+  _wp rewrite flush --hard --quiet
+  run get_rest_url
+  assert_success
+  # With plain permalinks, expect ?rest_route= based on home_url
+  # Check if it contains the problematic /wp-json/wp/ segment (it shouldn't)
+  refute_output --partial "/wp-json/wp/"
+  # Check if it contains the expected ?rest_route=
+  assert_output --partial "?rest_route=/"
+
+  # Restore pretty permalinks for subsequent tests
+  _wp option update permalink_structure '/%postname%/' --quiet
+  _wp rewrite flush --hard --quiet
+}
+
+@test "Check REST URL with pretty permalinks *before* flush (Simulates new site)" {
+  # Set pretty permalinks *without* flushing
+  _wp option update permalink_structure '/%postname%/' --quiet
+  # DO NOT FLUSH HERE
+
+  # Check home_url path to confirm /wp setup
+  run get_home_url_path
+  assert_success
+  assert_output "/wp"
+
+  # Now check get_rest_url() - this is where the original issue might occur
+  run get_rest_url
+  assert_success
+  # Assert that the output *should* be the correct /wp/wp-json/ even before flush,
+  # assuming the fix (either integrated or separate filter) is in place.
+  # If the fix is NOT in place, this might output /wp-json/ and fail.
+  # If the plain permalink fix was active, it might output /wp/wp-json/wp/ and fail.
+  assert_output --partial "/wp/wp-json/"
+  refute_output --partial "/wp-json/wp/" # Ensure the bad structure isn't present
+
+  # Clean up: Flush permalinks
+  _wp rewrite flush --hard --quiet
+}
+
+@test "Access pretty REST API path directly with plain permalinks active" {
+  # Set plain permalinks and flush
+  _wp option update permalink_structure '' --quiet
+  _wp rewrite flush --hard --quiet
+
+  # Get the full home URL to construct the test URL
+  SITE_URL=$( _wp option get home )
+  # Construct the pretty-style REST API URL
+  # Note: home_url() includes /wp, so we append /wp-json/... directly
+  TEST_URL="${SITE_URL}/wp-json/wp/v2/posts"
+
+  # Make a curl request to the pretty URL
+  # -s: silent, -o /dev/null: discard body, -w '%{http_code}': output only HTTP code
+  # -L: follow redirects (we expect NO redirect, so this helps verify)
+  # We expect a 200 OK if the internal handling works, or maybe 404 if not found,
+  # but crucially NOT a 301/302 redirect.
+  run curl -s -o /dev/null -w '%{http_code}' -L "${TEST_URL}"
+  assert_success
+  # Assert that the final HTTP status code is 200 (OK)
+  # If it were redirecting, -L would follow, but the *initial* code wouldn't be 200.
+  # If the internal handling fails, it might be 404 or other error.
+  assert_output "200"
+
+  # Restore pretty permalinks for subsequent tests
+  _wp option update permalink_structure '/%postname%/' --quiet
+  _wp rewrite flush --hard --quiet
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       env:
         CI: 1
       run: |
-          bats -p -t .github/tests
+          bats -p -t .github/tests/1-test-update-php.bats
 
     - name: Create failure status artifact
       if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: WordPress Composer Playwright Tests
+name: WordPress Composer Tests
 on:
   pull_request:
     paths-ignore:
@@ -29,12 +29,15 @@ permissions:
 
 jobs:
 
-  playwright-single:
+  test-single:
     name: Single site
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Bats
+        uses: bats-core/bats-action@2.0.0
 
       - name: Wait for status artifacts
         env:
@@ -154,17 +157,30 @@ jobs:
           SITE_URL: ${{ env.SITE_URL }}
         run: npm run test .github/tests/wpcm.spec.ts
 
+      - name: Run Bats tests for URL fixes (Single Site)
+        env:
+          SITE_ID: wpcm-playwright-tests
+          TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+        run: |
+          echo "Running REST URL Bats tests..."
+          terminus auth:login --machine-token="${TERMINUS_TOKEN}" || echo "Terminus already logged in."
+          # Corrected path to the test file
+          bats -p -t .github/tests/rest-url-fix.bats
+
       - name: Delete Site
         if: success()
         shell: bash
         run: terminus site:delete wpcm-playwright-tests -y
 
-  playwright-subdir:
+  test-subdir:
     name: Subdirectory multisite
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Bats
+        uses: bats-core/bats-action@2.0.0
 
       - name: Wait for status artifacts
         env:
@@ -287,17 +303,34 @@ jobs:
           echo "Running Playwright tests on WordPress subdirectory subsite"
             npm run test .github/tests/wpcm.spec.ts
 
+      - name: Run Bats tests for URL fixes
+        # This step runs *after* the site setup, including the initial permalink flush.
+        # The Bats test itself handles permalink changes for specific test cases.
+        # We need to pass the SITE_ID to the Bats test environment so WP-CLI commands work via Terminus.
+        env:
+          SITE_ID: wpcm-subdir-playwright-tests
+          SUBSITE: foo
+          TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+        run: |
+          echo "Running REST URL Bats tests..."
+          # Ensure Terminus is logged in if needed by Bats WP-CLI calls
+          terminus auth:login --machine-token="${TERMINUS_TOKEN}" || echo "Terminus already logged in."
+          bats -p -t .github/tests/2-rest-url-fix.bats
+
       - name: Delete Site
         if: success()
         shell: bash
         run: terminus site:delete wpcm-subdir-playwright-tests -y
 
-  playwright-subdom:
+  test-subdom:
     name: Subdomain multisite
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install Bats
+        uses: bats-core/bats-action@2.0.0
 
       - name: Wait for status artifacts
         env:
@@ -464,3 +497,20 @@ jobs:
           SITE_URL: ${{ env.SUBDOMAIN_URL }}
           GRAPHQL_ENDPOINT: ${{ env.SUBDOMAIN_URL }}/wp/graphql
         run: npm run test .github/tests/wpcm.spec.ts
+
+      - name: Run Bats tests for URL fixes (Subdomain)
+        env:
+          SITE_ID: wpcm-subdom-playwright-tests
+          SUBSITE: foo
+          TERMINUS_TOKEN: ${{ secrets.TERMINUS_TOKEN }}
+        run: |
+          echo "Running REST URL Bats tests..."
+          terminus auth:login --machine-token="${TERMINUS_TOKEN}" || echo "Terminus already logged in."
+          # Corrected path to the test file
+          bats -p -t .github/tests/rest-url-fix.bats
+
+      - name: Delete Site
+        # Run always to ensure cleanup
+        if: always()
+        shell: bash
+        run: terminus site:delete wpcm-subdom-playwright-tests -y


### PR DESCRIPTION
- [ ] Hold for #181 to be merged to `default`

This PR adds tests that validate that API endpoints can still be hit appropriately when a site is using "plain permalinks".