### PR TITLE
Fixes missing script error

### DIFF
--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -108,7 +108,7 @@ class ComposerScripts
             }
         }
 
-        $maybe_add_symlinks = '@maybe-add-symlinks';
+        $maybe_add_symlinks = '@maybe-create-symlinks';
         // Check if @maybe-add-symlinks is already in post-update-cmd. If not, add it.
         if (!in_array($maybe_add_symlinks, $composerJson['scripts']['post-update-cmd'])) {
             $io->write("<info>Adding $maybe_add_symlinks to post-update-cmd hook</info>");

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -206,14 +206,16 @@ class ComposerScripts
     {
         // Integrated Composer requires PHP 7.1 at a minimum.
         $patchVersions = [
-            '8.2' => '8.2.0',
-            '8.1' => '8.1.13',
-            '8.0' => '8.0.26',
+            '8.3' => '8.3.14',
+            '8.2' => '8.2.26',
+            '8.1' => '8.1.31',
+          // EOL final patch version below this line.
+            '8.0' => '8.0.30',
             '7.4' => '7.4.33',
             '7.3' => '7.3.33',
             '7.2' => '7.2.34',
             '7.1' => '7.1.33',
-        ];
+          ];
         if (isset($patchVersions[$pantheonPhpVersion])) {
             return $patchVersions[$pantheonPhpVersion];
         }


### PR DESCRIPTION
This PR fixes the ComposerScripts.php where the `maybe-add-symlinks` post-install script is run. `maybe-add-symlinks` doesn't actually exist -- instead `maybe-create-symlinks` is the correct script. This resulted in `maybe-create-symlinks` not actually running when it was supposed to and Composer returning an error.

This PR also updates the PHP versions in the platform check.