### PR TITLE
Resolve PHP 8.1 warning for rtrim() in functions.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.34.0 ()
+* Resolves rtrim warning in PHP 8.1+ environments. ([#189](https://github.com/pantheon-systems/wordpress-composer-managed/pull/189)) props @mattmacneil
+
 ### v1.33.0 (2025-05-08)
 * Fixes an issue where we were running `maybe-add-symlinks` but the script didn't exist. ([#183](https://github.com/pantheon-systems/wordpress-composer-managed/pull/183))
 * Fixes an issue where WP REST API urls would break on new sites before "pretty permalink" structure was set. ([#186](https://github.com/pantheon-systems/wordpress-composer-managed/pull/186))

--- a/web/app/mu-plugins/filters.php
+++ b/web/app/mu-plugins/filters.php
@@ -52,7 +52,7 @@ function fix_core_resource_urls( string $url ) : string {
 	$main_site_url = trailingslashit( is_multisite() ? network_site_url( '/' ) : home_url() );
 
 	// Get the current site path. Covers a variety of scenarios since we're using this function on a bunch of different filters.
-	$current_site_path = trailingslashit( parse_url( get_home_url(), PHP_URL_PATH ) ); // Define a default path.
+	$current_site_path = trailingslashit( parse_url( get_home_url(), PHP_URL_PATH ) ?? '' ); // Define a default path.
 	if ( is_multisite() ) {
 		if ( isset( $current_blog ) && ! empty( $current_blog->path ) ) {
 			$current_site_path = trailingslashit( $current_blog->path );


### PR DESCRIPTION
Got rid of rtrim() deprecation that was logged for each page load in my local dev environment. 

The issue was that trailingslashit() was sometimes getting a null value from parse_url(), which throwa a warning in php 8.1.

Updated line uses ?? operator so it always passes a string instead of null.