### PR TITLE
Sync with upstream Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
 - Easy WordPress configuration with environment specific files
 - Environment variables with [Dotenv](https://github.com/vlucas/phpdotenv)
 - Autoloader for mu-plugins (use regular plugins as mu-plugins)
-- Enhanced security (separated web root and secure passwords with [wp-password-bcrypt](https://github.com/roots/wp-password-bcrypt))
+- Enhanced security with separated web root
 
 ## How to use this project
 There are two main ways to interact with this project template. **Using the Pantheon-maintained WordPress Composer Managed upstream** or **forking this repository to create a custom upstream.**
@@ -97,9 +97,9 @@ Bedrock installs WordPress as a required package so updates can be managed by Co
 
 [Packagist](https://packagist.org) is a repository of Composer packages that are available by default to projects managed by Composer. Packagist libraries receive updates from their source GitHub repositories automatically.
 
-[WPackagist](https://wpackagist.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box. 
+[WP Packages](https://wp-packages.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box.
 
-You may install packages from Packagist or WPackagist without any additional configuration using `composer require`.
+You may install packages from Packagist or WP Packages without any additional configuration using `composer require`.
 
 #### Requiring a package from Packagist
 
@@ -111,16 +111,16 @@ composer require yoast/wordpress-seo
 
 Packages that are flagged as `wordpress-plugin`, `wordpress-theme` or `wordpress-muplugin` in their `composer.json` files will be installed automatically in the appropriate `web/app/` directory by Composer.
 
-#### Requiring a package from WPackagist
+#### Requiring a package from WP Packages
 
-For all other plugins and themes that are not managed on Packagist, you can use `composer require` as well, using `wpackagist-plugin` or `wpackagist-theme` as the vendor and the plugin or theme slug as the package name.
-
-```
-composer require wpackagist-theme/twentytwentytwo
-```
+For all other plugins and themes that are not managed on Packagist, you can use `composer require` as well, using `wp-plugin` or `wp-theme` as the vendor and the plugin or theme slug as the package name.
 
 ```
-composer require wpackagist-plugin/advanced-custom-fields
+composer require wp-theme/twentytwentyfive
+```
+
+```
+composer require wp-plugin/advanced-custom-fields
 ```
 
 ### Using Roots Sage starter theme

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "https://wpackagist.org",
-      "only": ["wpackagist-plugin/*", "wpackagist-theme/*"]
+      "url": "https://repo.wp-packages.org",
+      "only": ["wp-plugin/*", "wp-theme/*"]
     },
     {
         "type": "path",
@@ -51,29 +51,29 @@
   "require": {
     "php": ">=8.0",
     "composer/installers": "^2.2",
-    "vlucas/phpdotenv": "^5.5",
+    "cweagans/composer-patches": "^1.7",
     "oscarotero/env": "^2.1",
+    "pantheon-systems/pantheon-mu-plugin": "*",
+    "pantheon-upstreams/upstream-configuration": "dev-main",
     "roots/bedrock-autoloader": "*",
     "roots/bedrock-disallow-indexing": "*",
     "roots/wordpress": "*",
     "roots/wp-config": "*",
-    "roots/wp-password-bcrypt": "*",
-    "wpackagist-theme/twentytwentytwo": "^1.2",
-    "pantheon-systems/pantheon-mu-plugin": "*",
-    "pantheon-upstreams/upstream-configuration": "dev-main",
-    "wpackagist-plugin/pantheon-advanced-page-cache": "*",
-    "wpackagist-plugin/wp-native-php-sessions": "*",
-    "cweagans/composer-patches": "^1.7"
+    "vlucas/phpdotenv": "^5.5",
+    "wp-plugin/pantheon-advanced-page-cache": "*",
+    "wp-plugin/wp-native-php-sessions": "*",
+    "wp-theme/twentytwentyfive": "^1.0"
   },
   "require-dev": {
+    "assertwell/shellcheck": "^1.0",
     "pantheon-systems/pantheon-wp-coding-standards": "*",
-    "roave/security-advisories": "dev-latest",
-    "assertwell/shellcheck": "^1.0"
+    "roave/security-advisories": "dev-latest"
   },
   "config": {
     "optimize-autoloader": true,
     "preferred-install": "dist",
     "process-timeout": 0,
+    "sort-packages": true,
     "allow-plugins": {
       "composer/installers": true,
       "roots/wordpress-core-installer": true,

--- a/config/application.php
+++ b/config/application.php
@@ -11,7 +11,12 @@ use Roots\WPConfig\Config;
 use function Env\env;
 
 // USE_ENV_ARRAY + CONVERT_* + STRIP_QUOTES.
-Env\Env::$options = 31;
+Env\Env::$options
+	= Env\Env::USE_ENV_ARRAY
+	| Env\Env::CONVERT_BOOL
+	| Env\Env::CONVERT_NULL
+	| Env\Env::CONVERT_INT
+	| Env\Env::STRIP_QUOTES;
 
 /**
  * Directory containing all of the site's files
@@ -60,8 +65,36 @@ require_once __DIR__ . '/application.pantheon.php';
 define( 'WP_ENV', env( 'WP_ENV' ) ?: 'production' );
 
 /**
+ * Set WP_ENVIRONMENT_TYPE if not already defined
+ */
+if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+	$wp_environment_type = env( 'WP_ENVIRONMENT_TYPE' );
+
+	if ( $wp_environment_type ) {
+		Config::define( 'WP_ENVIRONMENT_TYPE', $wp_environment_type );
+	} elseif ( in_array( WP_ENV, [ 'production', 'staging', 'development', 'local' ], true ) ) {
+		Config::define( 'WP_ENVIRONMENT_TYPE', WP_ENV );
+	}
+}
+
+/**
+ * Set WP_DEVELOPMENT_MODE if explicitly configured
+ */
+if ( ! defined( 'WP_DEVELOPMENT_MODE' ) ) {
+	$wp_development_mode = env( 'WP_DEVELOPMENT_MODE' );
+
+	if ( $wp_development_mode ) {
+		Config::define( 'WP_DEVELOPMENT_MODE', $wp_development_mode );
+	}
+}
+
+/**
  * DB settings
  */
+if ( env( 'DB_SSL' ) ) {
+	Config::define( 'MYSQL_CLIENT_FLAGS', MYSQLI_CLIENT_SSL );
+}
+
 Config::define( 'DB_NAME', env( 'DB_NAME' ) );
 Config::define( 'DB_USER', env( 'DB_USER' ) );
 Config::define( 'DB_PASSWORD', env( 'DB_PASSWORD' ) );
@@ -116,12 +149,15 @@ Config::define( 'NONCE_SALT', env( 'NONCE_SALT' ) );
  * Custom Settings
  */
 Config::define( 'AUTOMATIC_UPDATER_DISABLED', true );
+Config::define( 'DISABLE_WP_CRON', env( 'DISABLE_WP_CRON' ) ?: false );
 // Disable the plugin and theme file editor in the admin.
 Config::define( 'DISALLOW_FILE_EDIT', true );
 // Disable plugin and theme updates and installation from the admin.
 Config::define( 'DISALLOW_FILE_MODS', true );
 // Limit the number of post revisions that Wordpress stores (true (default WP): store every revision).
 Config::define( 'WP_POST_REVISIONS', env( 'WP_POST_REVISIONS' ) ?? true );
+// Disable script concatenation.
+Config::define( 'CONCATENATE_SCRIPTS', false );
 
 /**
  * Debugging Settings

--- a/devops/files/composer-managed-README.md
+++ b/devops/files/composer-managed-README.md
@@ -28,7 +28,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
 - Easy WordPress configuration with environment specific files
 - Environment variables with [Dotenv](https://github.com/vlucas/phpdotenv)
 - Autoloader for mu-plugins (use regular plugins as mu-plugins)
-- Enhanced security (separated web root and secure passwords with [wp-password-bcrypt](https://github.com/roots/wp-password-bcrypt))
+- Enhanced security with separated web root
 
 ## How to use this project
 There are two main ways to interact with this project template. **Using the Pantheon-maintained WordPress Composer Managed upstream** or **forking this repository to create a custom upstream.**
@@ -92,9 +92,9 @@ Bedrock installs WordPress as a required package so updates can be managed by Co
 
 [Packagist](https://packagist.org) is a repository of Composer packages that are available by default to projects managed by Composer. Packagist libraries receive updates from their source GitHub repositories automatically.
 
-[WPackagist](https://wpackagist.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box. 
+[WP Packages](https://wp-packages.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box.
 
-You may install packages from Packagist or WPackagist without any additional configuration using `composer require`.
+You may install packages from Packagist or WP Packages without any additional configuration using `composer require`.
 
 #### Requiring a package from Packagist
 
@@ -106,16 +106,16 @@ composer require yoast/wordpress-seo
 
 Packages that are flagged as `wordpress-plugin`, `wordpress-theme` or `wordpress-muplugin` in their `composer.json` files will be installed automatically in the appropriate `web/app/` directory by Composer.
 
-#### Requiring a package from WPackagist
+#### Requiring a package from WP Packages
 
-For all other plugins and themes that are not managed on Packagist, you can use `composer require` as well, using `wpackagist-plugin` or `wpackagist-theme` as the vendor and the plugin or theme slug as the package name.
-
-```
-composer require wpackagist-theme/twentytwentytwo
-```
+For all other plugins and themes that are not managed on Packagist, you can use `composer require` as well, using `wp-plugin` or `wp-theme` as the vendor and the plugin or theme slug as the package name.
 
 ```
-composer require wpackagist-plugin/advanced-custom-fields
+composer require wp-theme/twentytwentyfive
+```
+
+```
+composer require wp-plugin/advanced-custom-fields
 ```
 
 ### Using Roots Sage starter theme

--- a/devops/files/decoupled-README.md
+++ b/devops/files/decoupled-README.md
@@ -28,7 +28,7 @@ Much of the philosophy behind Bedrock is inspired by the [Twelve-Factor App](htt
 - Easy WordPress configuration with environment specific files
 - Environment variables with [Dotenv](https://github.com/vlucas/phpdotenv)
 - Autoloader for mu-plugins (use regular plugins as mu-plugins)
-- Enhanced security (separated web root and secure passwords with [wp-password-bcrypt](https://github.com/roots/wp-password-bcrypt))
+- Enhanced security with separated web root
 
 ## How to use this project
 There are two main ways to interact with this project template. **Using the Pantheon-maintained WordPress Composer Managed upstream** or **forking this repository to create a custom upstream.**
@@ -92,9 +92,9 @@ Bedrock installs WordPress as a required package so updates can be managed by Co
 
 [Packagist](https://packagist.org) is a repository of Composer packages that are available by default to projects managed by Composer. Packagist libraries receive updates from their source GitHub repositories automatically.
 
-[WPackagist](https://wpackagist.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box. 
+[WP Packages](https://wp-packages.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box.
 
-You may install packages from Packagist or WPackagist without any additional configuration using `composer require`.
+You may install packages from Packagist or WP Packages without any additional configuration using `composer require`.
 
 #### Requiring a package from Packagist
 
@@ -106,16 +106,16 @@ composer require yoast/wordpress-seo
 
 Packages that are flagged as `wordpress-plugin`, `wordpress-theme` or `wordpress-muplugin` in their `composer.json` files will be installed automatically in the appropriate `web/app/` directory by Composer.
 
-#### Requiring a package from WPackagist
+#### Requiring a package from WP Packages
 
-For all other plugins and themes that are not managed on Packagist, you can use `composer require` as well, using `wpackagist-plugin` or `wpackagist-theme` as the vendor and the plugin or theme slug as the package name.
-
-```
-composer require wpackagist-theme/twentytwentytwo
-```
+For all other plugins and themes that are not managed on Packagist, you can use `composer require` as well, using `wp-plugin` or `wp-theme` as the vendor and the plugin or theme slug as the package name.
 
 ```
-composer require wpackagist-plugin/advanced-custom-fields
+composer require wp-theme/twentytwentyfive
+```
+
+```
+composer require wp-plugin/advanced-custom-fields
 ```
 
 ### Using Roots Sage starter theme

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -5,7 +5,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "https://wpackagist.org"
+            "url": "https://repo.wp-packages.org"
         }
     ],
     "require": {


### PR DESCRIPTION
This PR syncs upstream Bedrock changes into the Pantheon fork

- WPackagist → WP Packages
- Removed `roots/wp-password-bcrypt` (WordPress 6.8 ships native bcrypt password hashing)
- `config/application.php` changes:
    - **`Env\Env::$options` as named constants** — replaces the magic value `31` with explicit flags ([Bedrock reference](https://github.com/roots/bedrock/blob/0d38b039ed2f5937b52ca813ca9195de5f63b0cf/config/application.php#L16C1-L22)). Pantheon's flag set is preserved exactly: `USE_ENV_ARRAY` is kept (needed for the `$_ENV[...]` syntax in `.env.example`), and `LOCAL_FIRST` is intentionally not added (Pantheon's Lando-aware loading handles env precedence differently).
    - **`WP_ENVIRONMENT_TYPE`** — derives from env or falls back to `WP_ENV` if it matches a recognized value.
    - **`WP_DEVELOPMENT_MODE`** — supports the WP 6.3+ development-mode flag via env.
    - **`DB_SSL`** — opt-in MySQL SSL (`MYSQLI_CLIENT_SSL`), no-op unless the env var is set.
    - **`DISABLE_WP_CRON`** — env-configurable for sites running cron externally.
    - **`CONCATENATE_SCRIPTS = false`** — Bedrock convention to disable WP's built-in script concatenation.
- `composer.json` housekeeping
    - **Default theme**: `wpackagist-theme/twentytwentytwo:^1.2` → `wp-theme/twentytwentyfive:^1.0`. The previous theme is from WP 5.9 (Jan 2022); twentytwentyfive is the current default in WP 6.7+.
    - **`"sort-packages": true`** added under `config:` — keeps `composer.lock` diffs deterministic.
    - Both `require` and `require-dev` alphabetized so `sort-packages` is meaningful immediately, not just for future additions.

Happy to adjust anything.

**Disclosure:** I'm one of the [Bedrock](https://roots.io/bedrock/) maintainers.