### PR TITLE
docs: fix 'variabled' typo in Environment Variables section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ We acknowledge and apologize for the continued use of the `master` branch name. 
 
 ### Environment Variables
 
-Bedrock makes use of an `.env` file to store environment variables. Pantheon takes care of many of these variabled in `.env.pantheon`. You may set your own environment variables in a new `.env` or environment variables that are local-only in `.env.local` using the `.env.example` as a guide. Wrap values that may contain non-alphanumeric characters with quotes, or they may be incorrectly parsed.
+Bedrock makes use of an `.env` file to store environment variables. Pantheon takes care of many of these variables in `.env.pantheon`. You may set your own environment variables in a new `.env` or environment variables that are local-only in `.env.local` using the `.env.example` as a guide. Wrap values that may contain non-alphanumeric characters with quotes, or they may be incorrectly parsed.
 
 - Database variables
   - `DB_NAME` - Database name


### PR DESCRIPTION
Tiny typo: 'variabled' → 'variables'.